### PR TITLE
Distributed benchmark worker implementation

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -102,6 +102,12 @@
 		</dependency>
 
 		<dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/BenchmarkWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/BenchmarkWorker.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.worker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import io.javalin.Javalin;
+
+/**
+ * A benchmark worker that listen for tasks to perform
+ */
+public class BenchmarkWorker {
+
+    static class Arguments {
+
+        @Parameter(names = { "-h", "--help" }, description = "Help message", help = true)
+        boolean help;
+
+        @Parameter(names = { "-p", "--port" }, description = "HTTP port to listen on")
+        public int httpPort = 8080;
+    }
+
+    public static void main(String[] args) throws Exception {
+        final Arguments arguments = new Arguments();
+        JCommander jc = new JCommander(arguments);
+        jc.setProgramName("benchmark-worker");
+
+        try {
+            jc.parse(args);
+        } catch (ParameterException e) {
+            System.err.println(e.getMessage());
+            jc.usage();
+            System.exit(-1);
+        }
+
+        if (arguments.help) {
+            jc.usage();
+            System.exit(-1);
+        }
+
+        // Dump configuration variables
+        log.info("Starting benchmark with config: {}", writer.writeValueAsString(arguments));
+
+        // Start web server
+        Javalin app = Javalin.start(arguments.httpPort);
+
+        new WorkerHandler(app);
+    }
+
+    private static final ObjectWriter writer = new ObjectMapper().writerWithDefaultPrettyPrinter();
+
+    private static final Logger log = LoggerFactory.getLogger(BenchmarkWorker.class);
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
@@ -1,0 +1,322 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.worker;
+
+import static java.util.stream.Collectors.toList;
+import static org.asynchttpclient.Dsl.asyncHttpClient;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.DataFormatException;
+
+import org.HdrHistogram.Histogram;
+import org.apache.pulsar.client.util.FutureUtil;
+import org.asynchttpclient.AsyncHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.beust.jcommander.internal.Maps;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.openmessaging.benchmark.worker.commands.ConsumerAssignment;
+import io.openmessaging.benchmark.worker.commands.CountersStats;
+import io.openmessaging.benchmark.worker.commands.CumulativeLatencies;
+import io.openmessaging.benchmark.worker.commands.PeriodStats;
+import io.openmessaging.benchmark.worker.commands.ProducerWorkAssignment;
+import io.openmessaging.benchmark.worker.commands.TopicSubscription;
+import io.openmessaging.benchmark.worker.commands.TopicsInfo;
+
+public class DistributedWorkersEnsemble implements Worker {
+
+    private final List<String> workers;
+    private final List<String> producerWorkers;
+    private final List<String> consumerWorkers;
+
+    private final AsyncHttpClient httpClient = asyncHttpClient();
+
+    private int numberOfUsedProducerWorkers;
+
+    public DistributedWorkersEnsemble(List<String> workers) {
+        Preconditions.checkArgument(workers.size() > 1);
+
+        this.workers = workers;
+        List<List<String>> partitions = Lists.partition(workers, workers.size() / 2);
+        this.producerWorkers = partitions.get(0);
+        this.consumerWorkers = partitions.get(1);
+
+        log.info("Workers list - producers: {}", producerWorkers);
+        log.info("Workers list - consumers: {}", consumerWorkers);
+    }
+
+    @Override
+    public void initializeDriver(File configurationFile) throws IOException {
+        byte[] confFileContent = Files.readAllBytes(Paths.get(configurationFile.toString()));
+        sendPost(workers, "/initialize-driver", confFileContent);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<String> createTopics(TopicsInfo topicsInfo) throws IOException {
+        // Create all topics from a single worker node
+        return (List<String>) post(workers.get(0), "/create-topics", writer.writeValueAsBytes(topicsInfo), List.class)
+                .join();
+    }
+
+    @Override
+    public void createProducers(List<String> topics) {
+        List<List<String>> topicsPerProducer = Lists.partition(topics,
+                Math.max(1, topics.size() / producerWorkers.size()));
+        Map<String, List<String>> topicsPerProducerMap = Maps.newHashMap();
+        int i = 0;
+        for (List<String> assignedTopics : topicsPerProducer) {
+            topicsPerProducerMap.put(producerWorkers.get(i++), assignedTopics);
+        }
+
+        // Number of actually used workers might be less than available workers
+        numberOfUsedProducerWorkers = i;
+
+        List<CompletableFuture<Void>> futures = topicsPerProducerMap.keySet().stream().map(producer -> {
+            try {
+                return sendPost(producer, "/create-producers",
+                        writer.writeValueAsBytes(topicsPerProducerMap.get(producer)));
+            } catch (Exception e) {
+                CompletableFuture<Void> future = new CompletableFuture<>();
+                future.completeExceptionally(e);
+                return future;
+            }
+        }).collect(toList());
+
+        FutureUtil.waitForAll(futures).join();
+    }
+
+    @Override
+    public void startLoad(ProducerWorkAssignment producerWorkAssignment) throws IOException {
+        // Reduce the publish rate across all the brokers
+        producerWorkAssignment.publishRate /= numberOfUsedProducerWorkers;
+        sendPost(producerWorkers, "/start-load", writer.writeValueAsBytes(producerWorkAssignment));
+    }
+
+    @Override
+    public void probeProducers() throws IOException {
+        sendPost(producerWorkers, "/probe-producers", new byte[0]);
+    }
+
+    @Override
+    public void adjustPublishRate(double publishRate) throws IOException {
+        // Reduce the publish rate across all the brokers
+        publishRate /= numberOfUsedProducerWorkers;
+        sendPost(producerWorkers, "/adjust-publish-rate", writer.writeValueAsBytes(publishRate));
+    }
+
+    @Override
+    public void stopAll() {
+        sendPost(workers, "/stop-all", new byte[0]);
+    }
+
+    @Override
+    public void pauseConsumers() throws IOException {
+        sendPost(consumerWorkers, "/pause-consumers", new byte[0]);
+    }
+
+    @Override
+    public void resumeConsumers() throws IOException {
+        sendPost(consumerWorkers, "/resume-consumers", new byte[0]);
+    }
+
+    @Override
+    public void createConsumers(ConsumerAssignment overallConsumerAssignment) {
+        List<List<TopicSubscription>> subscriptionsPerConsumer = Lists.partition(
+                overallConsumerAssignment.topicsSubscriptions,
+                Math.max(1, overallConsumerAssignment.topicsSubscriptions.size() / consumerWorkers.size()));
+        Map<String, ConsumerAssignment> topicsPerWorkerMap = Maps.newHashMap();
+        int i = 0;
+        for (List<TopicSubscription> tsl : subscriptionsPerConsumer) {
+            ConsumerAssignment individualAssignement = new ConsumerAssignment();
+            individualAssignement.topicsSubscriptions = tsl;
+            topicsPerWorkerMap.put(consumerWorkers.get(i++), individualAssignement);
+        }
+
+        List<CompletableFuture<Void>> futures = topicsPerWorkerMap.keySet().stream().map(consumer -> {
+            try {
+                return sendPost(consumer, "/create-consumers",
+                        writer.writeValueAsBytes(topicsPerWorkerMap.get(consumer)));
+            } catch (Exception e) {
+                CompletableFuture<Void> future = new CompletableFuture<>();
+                future.completeExceptionally(e);
+                return future;
+            }
+        }).collect(toList());
+
+        FutureUtil.waitForAll(futures).join();
+    }
+
+    @Override
+    public PeriodStats getPeriodStats() {
+        List<PeriodStats> individualStats = get(workers, "/period-stats", PeriodStats.class);
+        PeriodStats stats = new PeriodStats();
+        individualStats.forEach(is -> {
+            stats.messagesSent += is.messagesSent;
+            stats.bytesSent += is.bytesSent;
+            stats.messagesReceived += is.messagesReceived;
+            stats.bytesReceived += is.bytesReceived;
+            stats.totalMessagesSent += is.totalMessagesSent;
+            stats.totalMessagesReceived += is.totalMessagesReceived;
+
+            try {
+                stats.publishLatency.add(Histogram.decodeFromCompressedByteBuffer(
+                        ByteBuffer.wrap(is.publishLatencyBytes), TimeUnit.SECONDS.toMicros(30)));
+
+                stats.endToEndLatency.add(Histogram.decodeFromCompressedByteBuffer(
+                        ByteBuffer.wrap(is.endToEndLatencyBytes), TimeUnit.HOURS.toMicros(12)));
+            } catch (ArrayIndexOutOfBoundsException | DataFormatException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        return stats;
+    }
+
+    @Override
+    public CumulativeLatencies getCumulativeLatencies() {
+        List<CumulativeLatencies> individualStats = get(workers, "/cumulative-latencies", CumulativeLatencies.class);
+
+        CumulativeLatencies stats = new CumulativeLatencies();
+        individualStats.forEach(is -> {
+            try {
+                stats.publishLatency.add(Histogram.decodeFromCompressedByteBuffer(
+                        ByteBuffer.wrap(is.publishLatencyBytes), TimeUnit.SECONDS.toMicros(30)));
+            } catch (Exception e) {
+                log.error("Failed to decode publish latency: {}",
+                        ByteBufUtil.prettyHexDump(Unpooled.wrappedBuffer(is.publishLatencyBytes)));
+                throw new RuntimeException(e);
+            }
+
+            try {
+                stats.endToEndLatency.add(Histogram.decodeFromCompressedByteBuffer(
+                        ByteBuffer.wrap(is.endToEndLatencyBytes), TimeUnit.HOURS.toMicros(12)));
+            } catch (Exception e) {
+                log.error("Failed to decode end-to-end latency: {}",
+                        ByteBufUtil.prettyHexDump(Unpooled.wrappedBuffer(is.endToEndLatencyBytes)));
+                throw new RuntimeException(e);
+            }
+        });
+
+        return stats;
+
+    }
+
+    @Override
+    public CountersStats getCountersStats() throws IOException {
+        List<CountersStats> individualStats = get(workers, "/counters-stats", CountersStats.class);
+
+        CountersStats stats = new CountersStats();
+        individualStats.forEach(is -> {
+            stats.messagesSent += is.messagesSent;
+            stats.messagesReceived += is.messagesReceived;
+        });
+
+        return stats;
+    }
+
+    @Override
+    public void resetStats() throws IOException {
+        sendPost(workers, "/reset-stats", new byte[0]);
+    }
+
+    /**
+     * Send a request to multiple hosts and wait for all responses
+     */
+    private void sendPost(List<String> hosts, String path, byte[] body) {
+        FutureUtil.waitForAll(hosts.stream().map(w -> sendPost(w, path, body)).collect(toList())).join();
+    }
+
+    private CompletableFuture<Void> sendPost(String host, String path, byte[] body) {
+        return httpClient.preparePost(host + path).setBody(body).execute().toCompletableFuture().thenApply(x -> {
+            Preconditions.checkArgument(x.getStatusCode() == 200);
+            return (Void) null;
+        });
+    }
+
+    private <T> List<T> get(List<String> hosts, String path, Class<T> clazz) {
+        List<CompletableFuture<T>> futures = hosts.stream().map(w -> get(w, path, clazz)).collect(toList());
+
+        CompletableFuture<List<T>> resultFuture = new CompletableFuture<>();
+        FutureUtil.waitForAll(futures).thenRun(() -> {
+            resultFuture.complete(futures.stream().map(CompletableFuture::join).collect(toList()));
+        }).exceptionally(ex -> {
+            resultFuture.completeExceptionally(ex);
+            return null;
+        });
+
+        return resultFuture.join();
+    }
+
+    private <T> CompletableFuture<T> get(String host, String path, Class<T> clazz) {
+        return httpClient.prepareGet(host + path).execute().toCompletableFuture().thenApply(response -> {
+            try {
+                Preconditions.checkArgument(response.getStatusCode() == 200);
+                return mapper.readValue(response.getResponseBody(), clazz);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private <T> CompletableFuture<T> post(String host, String path, byte[] body, Class<T> clazz) {
+        return httpClient.preparePost(host + path).setBody(body).execute().toCompletableFuture().thenApply(response -> {
+            try {
+                Preconditions.checkArgument(response.getStatusCode() == 200);
+                return mapper.readValue(response.getResponseBody(), clazz);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Override
+    public void close() throws Exception {
+        httpClient.close();
+    }
+
+    private static final ObjectWriter writer = new ObjectMapper().writerWithDefaultPrettyPrinter();
+
+    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    static {
+        mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(DistributedWorkersEnsemble.class);
+
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -1,0 +1,343 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.worker;
+
+import static java.util.stream.Collectors.toList;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.HdrHistogram.Recorder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.io.BaseEncoding;
+import com.google.common.util.concurrent.RateLimiter;
+
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.openmessaging.benchmark.DriverConfiguration;
+import io.openmessaging.benchmark.driver.BenchmarkConsumer;
+import io.openmessaging.benchmark.driver.BenchmarkDriver;
+import io.openmessaging.benchmark.driver.BenchmarkProducer;
+import io.openmessaging.benchmark.driver.ConsumerCallback;
+import io.openmessaging.benchmark.utils.Timer;
+import io.openmessaging.benchmark.utils.distributor.KeyDistributor;
+import io.openmessaging.benchmark.worker.commands.ConsumerAssignment;
+import io.openmessaging.benchmark.worker.commands.CountersStats;
+import io.openmessaging.benchmark.worker.commands.CumulativeLatencies;
+import io.openmessaging.benchmark.worker.commands.PeriodStats;
+import io.openmessaging.benchmark.worker.commands.ProducerWorkAssignment;
+import io.openmessaging.benchmark.worker.commands.TopicsInfo;
+
+public class LocalWorker implements Worker, ConsumerCallback {
+
+    private BenchmarkDriver benchmarkDriver = null;
+
+    private List<BenchmarkProducer> producers = new ArrayList<>();
+    private List<BenchmarkConsumer> consumers = new ArrayList<>();
+
+    private final RateLimiter rateLimiter = RateLimiter.create(1.0);
+
+    private final ExecutorService executor = Executors.newCachedThreadPool(new DefaultThreadFactory("local-worker"));
+
+    private final LongAdder messagesSent = new LongAdder();
+    private final LongAdder bytesSent = new LongAdder();
+
+    private final LongAdder messagesReceived = new LongAdder();
+    private final LongAdder bytesReceived = new LongAdder();
+
+    private final LongAdder totalMessagesSent = new LongAdder();
+    private final LongAdder totalMessagesReceived = new LongAdder();
+
+    private final Recorder publishLatencyRecorder = new Recorder(TimeUnit.SECONDS.toMicros(60), 5);
+    private final Recorder cumulativePublishLatencyRecorder = new Recorder(TimeUnit.SECONDS.toMicros(60), 5);
+
+    private final Recorder endToEndLatencyRecorder = new Recorder(TimeUnit.HOURS.toMicros(12), 5);
+    private final Recorder endToEndCumulativeLatencyRecorder = new Recorder(TimeUnit.HOURS.toMicros(12), 5);
+
+    private boolean testCompleted = false;
+
+    private boolean consumersArePaused = false;
+
+    @Override
+    public void initializeDriver(File driverConfigFile) throws IOException {
+        Preconditions.checkArgument(benchmarkDriver == null);
+        testCompleted = false;
+
+        DriverConfiguration driverConfiguration = mapper.readValue(driverConfigFile, DriverConfiguration.class);
+
+        log.info("Driver: {}", writer.writeValueAsString(driverConfiguration));
+
+        try {
+            benchmarkDriver = (BenchmarkDriver) Class.forName(driverConfiguration.driverClass).newInstance();
+            benchmarkDriver.initialize(driverConfigFile);
+        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public List<String> createTopics(TopicsInfo topicsInfo) {
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        Timer timer = new Timer();
+
+        String topicPrefix = benchmarkDriver.getTopicNamePrefix();
+
+        List<String> topics = new ArrayList<>();
+        for (int i = 0; i < topicsInfo.numberOfTopics; i++) {
+            String topic = String.format("%s-%s-%04d", topicPrefix, getRandomString(), i);
+            topics.add(topic);
+            futures.add(benchmarkDriver.createTopic(topic, topicsInfo.numberOfPartitionsPerTopic));
+        }
+
+        futures.forEach(CompletableFuture::join);
+
+        log.info("Created {} topics in {} ms", topics.size(), timer.elapsedMillis());
+        return topics;
+    }
+
+    @Override
+    public void createProducers(List<String> topics) {
+        Timer timer = new Timer();
+
+        List<CompletableFuture<BenchmarkProducer>> futures = topics.stream()
+                .map(topic -> benchmarkDriver.createProducer(topic)).collect(toList());
+
+        futures.forEach(f -> producers.add(f.join()));
+        log.info("Created {} producers in {} ms", producers.size(), timer.elapsedMillis());
+    }
+
+    @Override
+    public void createConsumers(ConsumerAssignment consumerAssignment) {
+        Timer timer = new Timer();
+
+        List<CompletableFuture<BenchmarkConsumer>> futures = consumerAssignment.topicsSubscriptions.stream()
+                .map(ts -> benchmarkDriver.createConsumer(ts.topic, ts.subscription, this)).collect(toList());
+
+        futures.forEach(f -> consumers.add(f.join()));
+        log.info("Created {} consumers in {} ms", consumers.size(), timer.elapsedMillis());
+    }
+
+    @Override
+    public void startLoad(ProducerWorkAssignment producerWorkAssignment) {
+        int processors = Runtime.getRuntime().availableProcessors();
+
+        final Function<BenchmarkProducer, KeyDistributor> assignKeyDistributor = (any) -> KeyDistributor
+                .build(producerWorkAssignment.keyDistributorType);
+
+        rateLimiter.setRate(producerWorkAssignment.publishRate);
+
+        Lists.partition(producers, processors).stream()
+                .map(producersPerThread -> producersPerThread.stream()
+                        .collect(Collectors.toMap(Function.identity(), assignKeyDistributor)))
+                .forEach(producersWithKeyDistributor -> submitProducersToExecutor(producersWithKeyDistributor,
+                        producerWorkAssignment.payloadData));
+    }
+
+    @Override
+    public void probeProducers() throws IOException {
+        producers.forEach(
+                producer -> producer.sendAsync("key", new byte[10]).thenRun(() -> totalMessagesSent.increment()));
+    }
+
+    private void submitProducersToExecutor(Map<BenchmarkProducer, KeyDistributor> producersWithKeyDistributor,
+            byte[] payloadData) {
+        executor.submit(() -> {
+            try {
+                while (!testCompleted) {
+                    producersWithKeyDistributor.forEach((producer, producersKeyDistributor) -> {
+                        rateLimiter.acquire();
+                        final long sendTime = System.nanoTime();
+                        producer.sendAsync(producersKeyDistributor.next(), payloadData).thenRun(() -> {
+                            messagesSent.increment();
+                            totalMessagesSent.increment();
+                            bytesSent.add(payloadData.length);
+
+                            long latencyMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - sendTime);
+                            publishLatencyRecorder.recordValue(latencyMicros);
+                            cumulativePublishLatencyRecorder.recordValue(latencyMicros);
+                        }).exceptionally(ex -> {
+                            log.warn("Write error on message", ex);
+                            return null;
+                        });
+                    });
+                }
+            } catch (Throwable t) {
+                log.error("Got error", t);
+            }
+        });
+    }
+
+    @Override
+    public void adjustPublishRate(double publishRate) {
+        rateLimiter.setRate(publishRate);
+    }
+
+    @Override
+    public PeriodStats getPeriodStats() {
+        PeriodStats stats = new PeriodStats();
+        stats.messagesSent = messagesSent.sumThenReset();
+        stats.bytesSent = bytesSent.sumThenReset();
+        stats.messagesReceived = messagesReceived.sumThenReset();
+        stats.bytesReceived = bytesReceived.sumThenReset();
+        stats.totalMessagesSent = totalMessagesSent.sum();
+        stats.totalMessagesReceived = totalMessagesReceived.sum();
+
+        stats.publishLatency = publishLatencyRecorder.getIntervalHistogram();
+        stats.endToEndLatency = endToEndLatencyRecorder.getIntervalHistogram();
+        return stats;
+    }
+
+    @Override
+    public CumulativeLatencies getCumulativeLatencies() {
+        CumulativeLatencies latencies = new CumulativeLatencies();
+        latencies.publishLatency = cumulativePublishLatencyRecorder.getIntervalHistogram();
+        latencies.endToEndLatency = endToEndCumulativeLatencyRecorder.getIntervalHistogram();
+        return latencies;
+    }
+
+    @Override
+    public CountersStats getCountersStats() throws IOException {
+        CountersStats stats = new CountersStats();
+        stats.messagesSent = totalMessagesSent.sum();
+        stats.messagesReceived = totalMessagesReceived.sum();
+        return stats;
+    }
+
+    @Override
+    public void messageReceived(byte[] data, long publishTimestamp) {
+        messagesReceived.increment();
+        totalMessagesReceived.increment();
+        bytesReceived.add(data.length);
+
+        long now = System.currentTimeMillis();
+        long endToEndLatencyMicros = TimeUnit.MILLISECONDS.toMicros(now - publishTimestamp);
+        endToEndCumulativeLatencyRecorder.recordValue(endToEndLatencyMicros);
+        endToEndLatencyRecorder.recordValue(endToEndLatencyMicros);
+
+        while (consumersArePaused) {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public void pauseConsumers() throws IOException {
+        consumersArePaused = true;
+        log.info("Pausing consumers");
+    }
+
+    @Override
+    public void resumeConsumers() throws IOException {
+        consumersArePaused = false;
+        log.info("Resuming consumers");
+    }
+
+    @Override
+    public void resetStats() throws IOException {
+        publishLatencyRecorder.reset();
+        cumulativePublishLatencyRecorder.reset();
+        endToEndLatencyRecorder.reset();
+        endToEndCumulativeLatencyRecorder.reset();
+    }
+
+    @Override
+    public void stopAll() throws IOException {
+        testCompleted = true;
+        consumersArePaused = false;
+
+        publishLatencyRecorder.reset();
+        cumulativePublishLatencyRecorder.reset();
+        endToEndLatencyRecorder.reset();
+        endToEndCumulativeLatencyRecorder.reset();
+
+        messagesSent.reset();
+        bytesSent.reset();
+        messagesReceived.reset();
+        bytesReceived.reset();
+        totalMessagesSent.reset();
+        totalMessagesReceived.reset();
+
+        try {
+            Thread.sleep(100);
+
+            for (BenchmarkProducer producer : producers) {
+                producer.close();
+            }
+            producers.clear();
+
+            for (BenchmarkConsumer consumer : consumers) {
+                consumer.close();
+            }
+            consumers.clear();
+
+            if (benchmarkDriver != null) {
+                benchmarkDriver.close();
+                benchmarkDriver = null;
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        executor.shutdown();
+    }
+
+    private static final ObjectWriter writer = new ObjectMapper().writerWithDefaultPrettyPrinter();
+
+    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    static {
+        mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+    }
+
+    private static final Random random = new Random();
+
+    private static final String getRandomString() {
+        byte[] buffer = new byte[5];
+        random.nextBytes(buffer);
+        return BaseEncoding.base64Url().omitPadding().encode(buffer);
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(LocalWorker.class);
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/Worker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/Worker.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.worker;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import io.openmessaging.benchmark.worker.commands.ConsumerAssignment;
+import io.openmessaging.benchmark.worker.commands.CountersStats;
+import io.openmessaging.benchmark.worker.commands.CumulativeLatencies;
+import io.openmessaging.benchmark.worker.commands.PeriodStats;
+import io.openmessaging.benchmark.worker.commands.ProducerWorkAssignment;
+import io.openmessaging.benchmark.worker.commands.TopicsInfo;
+
+public interface Worker extends AutoCloseable {
+
+    void initializeDriver(File configurationFile) throws IOException;
+
+    List<String> createTopics(TopicsInfo topicsInfo) throws IOException;
+
+    void createProducers(List<String> topics) throws IOException;
+
+    void createConsumers(ConsumerAssignment consumerAssignment) throws IOException;
+
+    void probeProducers() throws IOException;
+
+    void startLoad(ProducerWorkAssignment producerWorkAssignment) throws IOException;
+
+    void adjustPublishRate(double publishRate) throws IOException;
+
+    void pauseConsumers() throws IOException;
+
+    void resumeConsumers() throws IOException;
+
+    CountersStats getCountersStats() throws IOException;
+
+    PeriodStats getPeriodStats() throws IOException;
+
+    CumulativeLatencies getCumulativeLatencies() throws IOException;
+
+    void resetStats() throws IOException;
+
+    void stopAll() throws IOException;
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/WorkerHandler.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/WorkerHandler.java
@@ -1,0 +1,188 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.worker;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.io.Files;
+
+import io.javalin.Context;
+import io.javalin.Javalin;
+import io.openmessaging.benchmark.worker.commands.ConsumerAssignment;
+import io.openmessaging.benchmark.worker.commands.CumulativeLatencies;
+import io.openmessaging.benchmark.worker.commands.PeriodStats;
+import io.openmessaging.benchmark.worker.commands.ProducerWorkAssignment;
+import io.openmessaging.benchmark.worker.commands.TopicsInfo;
+
+@SuppressWarnings("unchecked")
+public class WorkerHandler {
+
+    private final Worker localWorker = new LocalWorker();
+
+    public WorkerHandler(Javalin app) {
+        app.post("/initialize-driver", this::handleInitializeDriver);
+        app.post("/create-topics", this::handleCreateTopics);
+        app.post("/create-producers", this::handleCreateProducers);
+        app.post("/probe-producers", this::handleProbeProducers);
+        app.post("/create-consumers", this::handleCreateConsumers);
+        app.post("/pause-consumers", this::handlePauseConsumers);
+        app.post("/resume-consumers", this::handleResumeConsumers);
+        app.post("/start-load", this::handleStartLoad);
+        app.post("/adjust-publish-rate", this::handleAdjustPublishRate);
+        app.post("/stop-all", this::handleStopAll);
+        app.get("/period-stats", this::handlePeriodStats);
+        app.get("/cumulative-latencies", this::handleCumulativeLatencies);
+        app.get("/counters-stats", this::handleCountersStats);
+        app.post("/reset-stats", this::handleResetStats);
+    }
+
+    private void handleInitializeDriver(Context ctx) throws Exception {
+        // Save config to temp file
+        File tempFile = File.createTempFile("driver-configuration", "conf");
+        Files.write(ctx.bodyAsBytes(), tempFile);
+
+        localWorker.initializeDriver(tempFile);
+        tempFile.delete();
+    }
+
+    private void handleCreateTopics(Context ctx) throws Exception {
+        TopicsInfo topicsInfo = mapper.readValue(ctx.body(), TopicsInfo.class);
+        log.info("Received create topics request for topics: {}", ctx.body());
+        List<String> topics = localWorker.createTopics(topicsInfo);
+        ctx.result(writer.writeValueAsString(topics));
+    }
+
+    private void handleCreateProducers(Context ctx) throws Exception {
+        List<String> topics = (List<String>) mapper.readValue(ctx.body(), List.class);
+        log.info("Received create producers request for topics: {}", topics);
+        localWorker.createProducers(topics);
+    }
+
+    private void handleProbeProducers(Context ctx) throws Exception {
+        localWorker.probeProducers();
+    }
+
+    private void handleCreateConsumers(Context ctx) throws Exception {
+        ConsumerAssignment consumerAssignment = mapper.readValue(ctx.body(), ConsumerAssignment.class);
+
+        log.info("Received create consumers request for topics: {}", consumerAssignment.topicsSubscriptions);
+        localWorker.createConsumers(consumerAssignment);
+    }
+
+    private void handlePauseConsumers(Context ctx) throws Exception {
+        localWorker.pauseConsumers();
+    }
+
+    private void handleResumeConsumers(Context ctx) throws Exception {
+        localWorker.resumeConsumers();
+    }
+
+    private void handleStartLoad(Context ctx) throws Exception {
+        ProducerWorkAssignment producerWorkAssignment = mapper.readValue(ctx.body(), ProducerWorkAssignment.class);
+
+        log.info("Start load publish-rate: {} msg/s -- payload-size: {}", producerWorkAssignment.publishRate,
+                producerWorkAssignment.payloadData.length);
+
+        localWorker.startLoad(producerWorkAssignment);
+    }
+
+    private void handleAdjustPublishRate(Context ctx) throws Exception {
+        Double publishRate = mapper.readValue(ctx.body(), Double.class);
+        log.info("Adjust publish-rate: {} msg/s", publishRate);
+        localWorker.adjustPublishRate(publishRate);
+    }
+
+    private void handleStopAll(Context ctx) throws Exception {
+        log.info("Stop All");
+        localWorker.stopAll();
+    }
+
+    private void handlePeriodStats(Context ctx) throws Exception {
+        PeriodStats stats = localWorker.getPeriodStats();
+
+        // Serialize histograms
+        synchronized (histogramSerializationBuffer) {
+            histogramSerializationBuffer.clear();
+            stats.publishLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
+            stats.publishLatencyBytes = new byte[histogramSerializationBuffer.position()];
+            histogramSerializationBuffer.flip();
+            histogramSerializationBuffer.get(stats.publishLatencyBytes);
+
+            histogramSerializationBuffer.clear();
+            stats.endToEndLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
+            stats.endToEndLatencyBytes = new byte[histogramSerializationBuffer.position()];
+            histogramSerializationBuffer.flip();
+            histogramSerializationBuffer.get(stats.endToEndLatencyBytes);
+        }
+
+        ctx.result(writer.writeValueAsString(stats));
+    }
+
+    private void handleCumulativeLatencies(Context ctx) throws Exception {
+        CumulativeLatencies stats = localWorker.getCumulativeLatencies();
+
+        // Serialize histograms
+        synchronized (histogramSerializationBuffer) {
+            histogramSerializationBuffer.clear();
+            stats.publishLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
+            stats.publishLatencyBytes = new byte[histogramSerializationBuffer.position()];
+            histogramSerializationBuffer.flip();
+            histogramSerializationBuffer.get(stats.publishLatencyBytes);
+
+            histogramSerializationBuffer.clear();
+            stats.endToEndLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
+            stats.endToEndLatencyBytes = new byte[histogramSerializationBuffer.position()];
+            histogramSerializationBuffer.flip();
+            histogramSerializationBuffer.get(stats.endToEndLatencyBytes);
+        }
+
+        ctx.result(writer.writeValueAsString(stats));
+    }
+
+    private void handleCountersStats(Context ctx) throws Exception {
+        ctx.result(writer.writeValueAsString(localWorker.getCountersStats()));
+    }
+
+    private void handleResetStats(Context ctx) throws Exception {
+        log.info("Reset stats");
+        localWorker.resetStats();
+    }
+
+    private final ByteBuffer histogramSerializationBuffer = ByteBuffer.allocate(1024 * 1024);
+
+    private static final Logger log = LoggerFactory.getLogger(WorkerHandler.class);
+
+    private static final ObjectMapper mapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    static {
+        mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+    }
+
+    private static final ObjectWriter writer = new ObjectMapper().writerWithDefaultPrettyPrinter();
+
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/ConsumerAssignment.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/ConsumerAssignment.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.worker.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConsumerAssignment {
+    public List<TopicSubscription> topicsSubscriptions = new ArrayList<>();
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/CountersStats.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/CountersStats.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.worker.commands;
+
+public class CountersStats {
+    public long messagesSent;
+    public long messagesReceived;
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/CumulativeLatencies.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/CumulativeLatencies.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.worker.commands;
+
+import java.util.concurrent.TimeUnit;
+
+import org.HdrHistogram.Histogram;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class CumulativeLatencies {
+
+    @JsonIgnore
+    public Histogram publishLatency = new Histogram(TimeUnit.SECONDS.toMicros(60), 5);
+    public byte[] publishLatencyBytes;
+
+    @JsonIgnore
+    public Histogram endToEndLatency = new Histogram(TimeUnit.HOURS.toMicros(12), 5);
+    public byte[] endToEndLatencyBytes;
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/PeriodStats.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/PeriodStats.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.worker.commands;
+
+import java.util.concurrent.TimeUnit;
+
+import org.HdrHistogram.Histogram;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class PeriodStats {
+    public long messagesSent = 0;
+    public long bytesSent = 0;
+
+    public long messagesReceived = 0;
+    public long bytesReceived = 0;
+
+    public long totalMessagesSent = 0;
+    public long totalMessagesReceived = 0;
+
+    @JsonIgnore
+    public Histogram publishLatency = new Histogram(TimeUnit.SECONDS.toMicros(60), 5);
+    public byte[] publishLatencyBytes;
+
+    @JsonIgnore
+    public Histogram endToEndLatency = new Histogram(TimeUnit.HOURS.toMicros(12), 5);
+    public byte[] endToEndLatencyBytes;
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/ProducerWorkAssignment.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/ProducerWorkAssignment.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.worker.commands;
+
+import io.openmessaging.benchmark.utils.distributor.KeyDistributorType;
+
+public class ProducerWorkAssignment {
+    
+    public byte[] payloadData;
+    
+    public double publishRate;
+
+    public KeyDistributorType keyDistributorType;
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/TopicSubscription.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/TopicSubscription.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.worker.commands;
+
+public class TopicSubscription {
+    public String topic;
+    public String subscription;
+
+    public TopicSubscription() {
+    }
+
+    public TopicSubscription(String topic, String subscription) {
+        this.topic = topic;
+        this.subscription = subscription;
+    }
+
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/TopicsInfo.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/TopicsInfo.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.worker.commands;
+
+public class TopicsInfo {
+    public int numberOfTopics;
+    public int numberOfPartitionsPerTopic;
+
+    public TopicsInfo() {
+    }
+
+    public TopicsInfo(int numberOfTopics, int numberOfPartitionsPerTopic) {
+        this.numberOfTopics = numberOfTopics;
+        this.numberOfPartitionsPerTopic = numberOfPartitionsPerTopic;
+    }
+}

--- a/bin/benchmark-worker
+++ b/bin/benchmark-worker
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+if [ -d "./lib" ]; then
+        CLASSPATH=$CLASSPATH:lib/*
+else
+    CLASSPATH=benchmark-framework/target/classes:`cat benchmark-framework/target/classpath.txt`
+fi
+
+JVM_MEM="-Xms4G -Xmx4G -XX:+UseG1GC"
+JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
+
+java -server -cp $CLASSPATH $JVM_MEM io.openmessaging.benchmark.worker.BenchmarkWorker $*


### PR DESCRIPTION
Added distributed benchmark worker implementation. 

There is a new command `benchmark-worker` which spins up a process that list on an HTTP port and wait for instructions. 

The regular `benchmark` tool can work in 2 ways: 
 * Without any specified worker, it will do everything in a single JVM process as before
 * When passing a list of workers, it will use those to handle all the producers/consumers.

When running in distributed mode, the `benchmark` tool will take care of coordinating the workers and collecting all the stats to provide a single JSON result for the run.

cc/ @tsypuk 