### PR TITLE
Added terraform & ansible scripts to run the benchmark from multiple clients

### DIFF
--- a/driver-kafka/deploy/deploy.yaml
+++ b/driver-kafka/deploy/deploy.yaml
@@ -48,9 +48,8 @@
           - java
           - sysstat
           - vim
-    - file:
-        path: /opt/kafka
-        state: directory
+    - file: path=/opt/kafka state=absent
+    - file: path=/opt/kafka state=directory
     - set_fact:
         zookeeperServers: "{{ groups['zookeeper']|map('extract', hostvars, ['ansible_default_ipv4', 'address'])|map('regex_replace', '(.*)', '\\1:2181') | join(',') }}"
         boostrapServers: "{{ hostvars[groups['kafka'][0]].private_ip }}:9092"
@@ -112,24 +111,45 @@
   connection: ssh
   become: true
   tasks:
+    - file: path=/opt/benchmark state=absent
     - name: Copy benchmark code
       unarchive:
         src: ../../package/target/openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar.gz
         dest: /opt
-    - shell: >
-        tuned-adm profile latency-performance &&
-        mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
+    - shell: mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
+    - shell: tuned-adm profile latency-performance
+
+    - name: Get list of driver config files
+      raw: ls -1 /opt/benchmark/driver-kafka/*.yaml
+      register: drivers_list
+
     - name: Configure URL
       lineinfile:
          dest: /opt/benchmark/driver-kafka/kafka.yaml
          regexp: '^  bootstrap.servers='
          line: '  bootstrap.servers={{ boostrapServers }}'
-    - name: Configure http URL
+      with_items: '{{ drivers_list.stdout_lines }}'
+    - name: Configure memory
+      lineinfile:
+         dest: /opt/benchmark/bin/benchmark-worker
+         regexp: '^JVM_MEM='
+         line: 'JVM_MEM="-Xms12G -Xmx12G -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch -XX:-UseBiasedLocking"'
+    - name: Configure memory
       lineinfile:
          dest: /opt/benchmark/bin/benchmark
          regexp: '^JVM_MEM='
-         line: 'JVM_MEM="-Xms24G -Xmx24G -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch -XX:-UseBiasedLocking"'
-
+         line: 'JVM_MEM="-Xmx1G"'
+    - template:
+        src: "templates/workers.yaml"
+        dest: "/opt/benchmark/workers.yaml"
+    - name: Install benchmark systemd service
+      template:
+        src: "templates/benchmark-worker.service"
+        dest: "/etc/systemd/system/benchmark-worker.service"
+    - systemd:
+        state: restarted
+        daemon_reload: yes
+        name: "benchmark-worker"
 
 - name:  Hosts addresses
   hosts: localhost
@@ -142,5 +162,5 @@
         msg: "Kafka brokers {{ item }}"
       with_items: "{{ groups['kafka'] }}"
     - debug:
-        msg: "Benchmark client {{ item }}"
+        msg: "Benchmark clients {{ item }}"
       with_items: "{{ groups['client'] }}"

--- a/driver-kafka/deploy/provision-kafka-aws.tf
+++ b/driver-kafka/deploy/provision-kafka-aws.tf
@@ -127,7 +127,7 @@ resource "aws_instance" "client" {
   key_name               = "${aws_key_pair.auth.id}"
   subnet_id              = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count                  = 1
+  count                  = "${var.num_instances["client"]}"
 
   tags {
     Name = "kafka-client-${count.index}"

--- a/driver-kafka/deploy/terraform.tfvars
+++ b/driver-kafka/deploy/terraform.tfvars
@@ -5,10 +5,11 @@ ami             = "ami-9fa343e7" // RHEL-7.4
 instance_types = {
   "kafka"     = "i3.4xlarge"
   "zookeeper" = "t2.small"
-  "client"    = "c4.8xlarge"
+  "client"    = "c5.2xlarge"
 }
 
 num_instances = {
+  "client"    = 4
   "kafka"     = 3
   "zookeeper" = 3
 }

--- a/driver-pulsar/deploy/deploy.yaml
+++ b/driver-pulsar/deploy/deploy.yaml
@@ -59,10 +59,8 @@
         serviceUrl: "pulsar://{{ hostvars[groups['pulsar'][0]].private_ip }}:6650/"
         httpUrl: "http://{{ hostvars[groups['pulsar'][0]].private_ip }}:8080/"
         pulsarVersion: "1.21.0-incubating"
-    - name: Create Pulsar directory
-      file:
-        path: /opt/pulsar
-        state: directory
+    - file: path=/opt/pulsar state=absent
+    - file: path=/opt/pulsar state=directory
     - name: Download Pulsar binary package
       unarchive:
         src: "http://archive.apache.org/dist/incubator/pulsar/pulsar-{{ pulsarVersion }}/apache-pulsar-{{ pulsarVersion }}-bin.tar.gz"
@@ -172,12 +170,16 @@
       template:
         src: "templates/client.conf"
         dest: "/opt/pulsar/conf/client.conf"
+    - file: path=/opt/benchmark state=absent
     - name: Copy benchmark code
       unarchive:
         src: ../../package/target/openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar.gz
         dest: /opt
     - shell: mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
 
+    - template:
+        src: "templates/workers.yaml"
+        dest: "/opt/benchmark/workers.yaml"
     - name: Get list of driver config files
       raw: ls -1 /opt/benchmark/driver-pulsar/*.yaml
       register: drivers_list
@@ -194,11 +196,24 @@
          regexp: '^  httpUrl: '
          line: '  httpUrl: {{ httpUrl }}'
       with_items: '{{ drivers_list.stdout_lines }}'
-    - name: Configure http URL
+    - name: Configure memory
+      lineinfile:
+         dest: /opt/benchmark/bin/benchmark-worker
+         regexp: '^JVM_MEM='
+         line: 'JVM_MEM="-Xms12G -Xmx12G -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch -XX:-UseBiasedLocking"'
+    - name: Configure memory
       lineinfile:
          dest: /opt/benchmark/bin/benchmark
          regexp: '^JVM_MEM='
-         line: 'JVM_MEM="-Xms24G -Xmx24G -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch -XX:-UseBiasedLocking"'
+         line: 'JVM_MEM="-Xmx1G"'
+    - name: Install benchmark systemd service
+      template:
+        src: "templates/benchmark-worker.service"
+        dest: "/etc/systemd/system/benchmark-worker.service"
+    - systemd:
+        state: restarted
+        daemon_reload: yes
+        name: "benchmark-worker"
 
 
 - name: List host addresses
@@ -212,5 +227,5 @@
         msg: "Pulsar/BookKeeper servers {{ item }}"
       with_items: "{{ groups['pulsar'] }}"
     - debug:
-        msg: "Benchmark client {{ item }}"
+        msg: "Benchmark clients {{ item }}"
       with_items: "{{ groups['client'] }}"

--- a/driver-pulsar/deploy/provision-pulsar-aws.tf
+++ b/driver-pulsar/deploy/provision-pulsar-aws.tf
@@ -127,7 +127,7 @@ resource "aws_instance" "client" {
   key_name               = "${aws_key_pair.auth.id}"
   subnet_id              = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count                  = 1
+  count                  = "${var.num_instances["client"]}"
 
   tags {
     Name = "pulsar-client-${count.index}"

--- a/driver-pulsar/deploy/templates/benchmark-worker.service
+++ b/driver-pulsar/deploy/templates/benchmark-worker.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Pulsar Broker
+After=network.target
+
+[Service]
+ExecStart=/opt/benchmark/bin/benchmark-worker
+WorkingDirectory=/opt/benchmark
+RestartSec=1s
+Restart=on-failure
+Type=simple
+LimitNOFILE=300000
+
+[Install]
+WantedBy=multi-user.target

--- a/driver-pulsar/deploy/templates/workers.yaml
+++ b/driver-pulsar/deploy/templates/workers.yaml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+workers:
+{% for worker in groups['client'] %}
+  - http://{{ hostvars[worker].private_ip }}:8080
+{% endfor %}

--- a/driver-pulsar/deploy/terraform.tfvars
+++ b/driver-pulsar/deploy/terraform.tfvars
@@ -5,10 +5,11 @@ ami             = "ami-9fa343e7" // RHEL-7.4
 instance_types = {
   "pulsar"    = "i3.4xlarge"
   "zookeeper" = "t2.small"
-  "client"    = "c4.8xlarge"
+  "client"    = "c5.2xlarge"
 }
 
 num_instances = {
+  "client"    = 4
   "pulsar"    = 3
   "zookeeper" = 3
 }


### PR DESCRIPTION
Provision multiple small VMs for clients and configure to spin up `benchmak-worker` process in each of them. 
Prefills `workers.yaml` file with the list of available workers.