### PR TITLE
Add random hash to AWS resource names to avoid name conflicts

### DIFF
--- a/driver-pulsar/deploy/provision-pulsar-aws.tf
+++ b/driver-pulsar/deploy/provision-pulsar-aws.tf
@@ -1,3 +1,12 @@
+provider "aws" {
+  region  = "${var.region}"
+  version = "1.8"
+}
+
+provider "random" {
+  version = "1.1"
+}
+
 variable "public_key_path" {
   description = <<DESCRIPTION
 Path to the SSH public key to be used for authentication.
@@ -8,9 +17,13 @@ Example: ~/.ssh/pulsar_aws.pub
 DESCRIPTION
 }
 
+resource "random_id" "hash" {
+  byte_length = 8
+}
+
 variable "key_name" {
   default     = "pulsar-benchmark-key"
-  description = "Desired name of AWS key pair"
+  description = "Desired name prefix for the AWS key pair"
 }
 
 variable "region" {}
@@ -25,21 +38,17 @@ variable "num_instances" {
   type = "map"
 }
 
-provider "aws" {
-  region = "${var.region}"
-}
-
 # Create a VPC to launch our instances into
 resource "aws_vpc" "benchmark_vpc" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "Benchmark-VPC"
+    Name = "Pulsar-Benchmark-VPC-${random_id.hash.hex}"
   }
 }
 
 # Create an internet gateway to give our subnet access to the outside world
-resource "aws_internet_gateway" "default" {
+resource "aws_internet_gateway" "pulsar" {
   vpc_id = "${aws_vpc.benchmark_vpc.id}"
 }
 
@@ -47,7 +56,7 @@ resource "aws_internet_gateway" "default" {
 resource "aws_route" "internet_access" {
   route_table_id         = "${aws_vpc.benchmark_vpc.main_route_table_id}"
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.default.id}"
+  gateway_id             = "${aws_internet_gateway.pulsar.id}"
 }
 
 # Create a subnet to launch our instances into
@@ -58,7 +67,7 @@ resource "aws_subnet" "benchmark_subnet" {
 }
 
 resource "aws_security_group" "benchmark_security_group" {
-  name   = "terraform"
+  name   = "terraform-pulsar-${random_id.hash.hex}"
   vpc_id = "${aws_vpc.benchmark_vpc.id}"
 
   # SSH access from anywhere
@@ -86,12 +95,12 @@ resource "aws_security_group" "benchmark_security_group" {
   }
 
   tags {
-    Name = "Benchmark-Security-Group"
+    Name = "Benchmark-Security-Group-${random_id.hash.hex}"
   }
 }
 
 resource "aws_key_pair" "auth" {
-  key_name   = "${var.key_name}"
+  key_name   = "${var.key_name}-${random_id.hash.hex}"
   public_key = "${file(var.public_key_path)}"
 }
 


### PR DESCRIPTION
In this PR, I've used the `random_id` resource type for Terraform to add a random component to resource names that may be subject to naming clashes. I've also changed away from usage of the `default` name, which can also cause problems.