### PR TITLE
Fix YAML oddities

### DIFF
--- a/driver-rabbitmq/rabbitmq.yaml
+++ b/driver-rabbitmq/rabbitmq.yaml
@@ -18,7 +18,7 @@
 #
 
 
-name : RabbitMQ
+name: RabbitMQ
 driverClass: io.openmessaging.benchmark.driver.rabbitmq.RabbitMqBenchmarkDriver
 
 # RabbitMq client specific configurations

--- a/workloads/1-topic-1-partition-100b.yaml
+++ b/workloads/1-topic-1-partition-100b.yaml
@@ -17,14 +17,14 @@
 # under the License.
 #
 
-name: 1 topic / 1 partition / 1Kb
+name: 1 topic / 1 partition / 100b
 
-topics : 1
-partitionsPerTopic : 1
-messageSize : 100
+topics: 1
+partitionsPerTopic: 1
+messageSize: 100
 payloadFile: "payload/payload-100b.data"
-subscriptionsPerTopic : 1
-producersPerTopic : 1
-producerRate : 50000
-consumerBacklogSizeGB : 0
-testDurationMinutes : 15
+subscriptionsPerTopic: 1
+producersPerTopic: 1
+producerRate: 50000
+consumerBacklogSizeGB: 0
+testDurationMinutes: 15

--- a/workloads/1-topic-1-partition-1kb.yaml
+++ b/workloads/1-topic-1-partition-1kb.yaml
@@ -19,13 +19,13 @@
 
 name: 1 topic / 1 partition / 1Kb
 
-topics : 1
-partitionsPerTopic : 1
+topics: 1
+partitionsPerTopic: 1
 keyDistributor: "ROUND_ROBIN"
-messageSize : 1024
+messageSize: 1024
 payloadFile: "payload/payload-1Kb.data"
-subscriptionsPerTopic : 1
-producersPerTopic : 1
-producerRate : 50000
-consumerBacklogSizeGB : 0
-testDurationMinutes : 15
+subscriptionsPerTopic: 1
+producersPerTopic: 1
+producerRate: 50000
+consumerBacklogSizeGB: 0
+testDurationMinutes: 15

--- a/workloads/1-topic-16-partitions-1kb.yaml
+++ b/workloads/1-topic-16-partitions-1kb.yaml
@@ -19,12 +19,12 @@
 
 name: 1 producer / 1 consumers on 1 topic
 
-topics : 1
-partitionsPerTopic : 16
-messageSize : 1024
+topics: 1
+partitionsPerTopic: 16
+messageSize: 1024
 payloadFile: "payload/payload-1Kb.data"
-subscriptionsPerTopic : 1
-producersPerTopic : 1
-producerRate : 50000
-consumerBacklogSizeGB : 0
-testDurationMinutes : 15
+subscriptionsPerTopic: 1
+producersPerTopic: 1
+producerRate: 50000
+consumerBacklogSizeGB: 0
+testDurationMinutes: 15

--- a/workloads/1-topic-3-partition-100b-3producers.yaml
+++ b/workloads/1-topic-3-partition-100b-3producers.yaml
@@ -19,12 +19,12 @@
 
 name: 1 topic / 3 partition / 100b / 3 producers
 
-topics : 1
-partitionsPerTopic : 3
-messageSize : 100
+topics: 1
+partitionsPerTopic: 3
+messageSize: 100
 payloadFile: "payload/payload-100b.data"
-subscriptionsPerTopic : 1
-producersPerTopic : 3
-producerRate : 0
-consumerBacklogSizeGB : 0
-testDurationMinutes : 15
+subscriptionsPerTopic: 1
+producersPerTopic: 3
+producerRate: 0
+consumerBacklogSizeGB: 0
+testDurationMinutes: 15

--- a/workloads/backlog-1-topic-1-partition-1kb.yaml
+++ b/workloads/backlog-1-topic-1-partition-1kb.yaml
@@ -19,12 +19,12 @@
 
 name: 1 producer / 1 consumers on 1 topic
 
-topics : 1
-partitionsPerTopic : 1
-messageSize : 1024
+topics: 1
+partitionsPerTopic: 1
+messageSize: 1024
 payloadFile: "payload/payload-1Kb.data"
-subscriptionsPerTopic : 1
-producersPerTopic : 1
-producerRate : 100000
-consumerBacklogSizeGB : 100
-testDurationMinutes : 5
+subscriptionsPerTopic: 1
+producersPerTopic: 1
+producerRate: 100000
+consumerBacklogSizeGB: 100
+testDurationMinutes: 5

--- a/workloads/backlog-1-topic-16-partitions-1kb.yaml
+++ b/workloads/backlog-1-topic-16-partitions-1kb.yaml
@@ -19,12 +19,12 @@
 
 name: 1 producer / 1 consumers on 1 topic
 
-topics : 1
-partitionsPerTopic : 16
-messageSize : 1024
+topics: 1
+partitionsPerTopic: 16
+messageSize: 1024
 payloadFile: "payload/payload-1Kb.data"
-subscriptionsPerTopic : 1
-producersPerTopic : 1
-producerRate : 100000
-consumerBacklogSizeGB : 100
-testDurationMinutes : 5
+subscriptionsPerTopic: 1
+producersPerTopic: 1
+producerRate: 100000
+consumerBacklogSizeGB: 100
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-1-partition-100b.yaml
+++ b/workloads/max-rate-1-topic-1-partition-100b.yaml
@@ -19,15 +19,15 @@
 
 name: Max rate 1 producer on 1 topic / 1 partition
 
-topics : 1
-partitionsPerTopic : 1
-messageSize : 100
+topics: 1
+partitionsPerTopic: 1
+messageSize: 100
 payloadFile: "payload/payload-100b.data"
-subscriptionsPerTopic : 1
-producersPerTopic : 1
+subscriptionsPerTopic: 1
+producersPerTopic: 1
 
 # Discover max-sustainable rate
-producerRate : 0
+producerRate: 0
 
-consumerBacklogSizeGB : 0
-testDurationMinutes : 5
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-1-partition-1kb.yaml
+++ b/workloads/max-rate-1-topic-1-partition-1kb.yaml
@@ -19,15 +19,15 @@
 
 name: Max rate 1 producer on 1 topic / 1 partition
 
-topics : 1
-partitionsPerTopic : 1
-messageSize : 1024
+topics: 1
+partitionsPerTopic: 1
+messageSize: 1024
 payloadFile: "payload/payload-1Kb.data"
-subscriptionsPerTopic : 1
-producersPerTopic : 1
+subscriptionsPerTopic: 1
+producersPerTopic: 1
 
 # Discover max-sustainable rate
-producerRate : 0
+producerRate: 0
 
-consumerBacklogSizeGB : 0
-testDurationMinutes : 5
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-100-partitions-100b.yaml
+++ b/workloads/max-rate-1-topic-100-partitions-100b.yaml
@@ -19,15 +19,15 @@
 
 name: Max rate 1 producer on 1 topic / 100 partition / 100 bytes
 
-topics : 1
-partitionsPerTopic : 100
-messageSize : 100
+topics: 1
+partitionsPerTopic: 100
+messageSize: 100
 payloadFile: "payload/payload-100b.data"
-subscriptionsPerTopic : 1
-producersPerTopic : 1
+subscriptionsPerTopic: 1
+producersPerTopic: 1
 
 # Discover max-sustainable rate
-producerRate : 0
+producerRate: 0
 
-consumerBacklogSizeGB : 0
-testDurationMinutes : 5
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-100-partitions-1kb.yaml
+++ b/workloads/max-rate-1-topic-100-partitions-1kb.yaml
@@ -19,15 +19,15 @@
 
 name: Max rate 1 producer on 1 topic / 100 partition
 
-topics : 1
-partitionsPerTopic : 100
-messageSize : 1024
+topics: 1
+partitionsPerTopic: 100
+messageSize: 1024
 payloadFile: "payload/payload-1Kb.data"
-subscriptionsPerTopic : 1
-producersPerTopic : 1
+subscriptionsPerTopic: 1
+producersPerTopic: 1
 
 # Discover max-sustainable rate
-producerRate : 0
+producerRate: 0
 
-consumerBacklogSizeGB : 0
-testDurationMinutes : 5
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-16-partitions-100b.yaml
+++ b/workloads/max-rate-1-topic-16-partitions-100b.yaml
@@ -19,15 +19,15 @@
 
 name: Max rate 1 producer on 1 topic / 16 partitions
 
-topics : 1
-partitionsPerTopic : 16
-messageSize : 100
+topics: 1
+partitionsPerTopic: 16
+messageSize: 100
 payloadFile: "payload/payload-100b.data"
-subscriptionsPerTopic : 1
-producersPerTopic : 1
+subscriptionsPerTopic: 1
+producersPerTopic: 1
 
 # Discover max-sustainable rate
-producerRate : 0
+producerRate: 0
 
-consumerBacklogSizeGB : 0
-testDurationMinutes : 5
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-16-partitions-1kb.yaml
+++ b/workloads/max-rate-1-topic-16-partitions-1kb.yaml
@@ -19,15 +19,15 @@
 
 name: Max rate 1 producer on 1 topic / 1 partition
 
-topics : 1
-partitionsPerTopic : 16
-messageSize : 1024
+topics: 1
+partitionsPerTopic: 16
+messageSize: 1024
 payloadFile: "payload/payload-1Kb.data"
-subscriptionsPerTopic : 1
-producersPerTopic : 1
+subscriptionsPerTopic: 1
+producersPerTopic: 1
 
 # Discover max-sustainable rate
-producerRate : 0
+producerRate: 0
 
-consumerBacklogSizeGB : 0
-testDurationMinutes : 5
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/simple-workload.yaml
+++ b/workloads/simple-workload.yaml
@@ -20,22 +20,15 @@
 
 name: Simple Workload 1 producer on 1 topic
 
-topics : 1
-partitionsPerTopic : 10
-
-messageSize : 1024
+topics: 1
+partitionsPerTopic: 10
+messageSize: 1024
 payloadFile: "payload/payload-1Kb.data"
-
-subscriptionsPerTopic : 1
-
-producersPerTopic : 1
-
-consumerPerSubscription : 1
-
-producerRate : 10000
-
-consumerBacklogSizeGB : 0
-
-testDurationMinutes : 5
+subscriptionsPerTopic: 1
+producersPerTopic: 1
+consumerPerSubscription: 1
+producerRate: 10000
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5
 
 


### PR DESCRIPTION
This PR fixes one incorrect `name` for a workload and removes extraneous spaces before colons (spaces before colons are _not_ standard YAML)