### PR TITLE
Make distributed mode default. 

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -89,9 +89,9 @@ public class Benchmark {
         }
 
         if (arguments.workers == null && arguments.workersFile == null) {
-            log.info("Using default worker file workers.yaml");
             File defaultFile = new File("workers.yaml");
             if (defaultFile.exists()) {
+                log.info("Using default worker file workers.yaml");
                 arguments.workersFile = defaultFile;
             }
         }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -88,6 +88,14 @@ public class Benchmark {
             System.exit(-1);
         }
 
+        if (arguments.workers == null && arguments.workersFile == null) {
+            log.info("Using default worker file workers.yaml");
+            File defaultFile = new File("workers.yaml");
+            if (defaultFile.exists()) {
+                arguments.workersFile = defaultFile;
+            }
+        }
+
         if (arguments.workersFile != null) {
             log.info("Reading workers list from {}", arguments.workersFile);
             arguments.workers = mapper.readValue(arguments.workersFile, Workers.class).workers;


### PR DESCRIPTION
If neither workers file nor workers is specified, try to read from the wokers.yaml file if it exists.