### PR TITLE
Upgrade pulsar version to 1.22.0-incubating

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -60,9 +60,25 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.fasterxml.jackson.jaxrs</groupId>
+			<artifactId>jackson-jaxrs-base</artifactId>
+			<version>2.9.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.jaxrs</groupId>
+			<artifactId>jackson-jaxrs-json-provider</artifactId>
+			<version>2.9.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>2.9.3</version>
+		</dependency>
+
+		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
-			<version>${log4j.version}</version>
+			<version>2.9.3</version>
 		</dependency>
 
 		<dependency>

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.DataFormatException;
 
 import org.HdrHistogram.Histogram;
-import org.apache.pulsar.client.util.FutureUtil;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.asynchttpclient.AsyncHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/driver-pulsar/deploy/deploy.yaml
+++ b/driver-pulsar/deploy/deploy.yaml
@@ -58,7 +58,7 @@
         zookeeperServers: "{{ groups['zookeeper']|map('extract', hostvars, ['ansible_default_ipv4', 'address'])|map('regex_replace', '(.*)', '\\1:2181') | join(',') }}"
         serviceUrl: "pulsar://{{ hostvars[groups['pulsar'][0]].private_ip }}:6650/"
         httpUrl: "http://{{ hostvars[groups['pulsar'][0]].private_ip }}:8080/"
-        pulsarVersion: "1.21.0-incubating"
+        pulsarVersion: "1.22.0-incubating"
     - file: path=/opt/pulsar state=absent
     - file: path=/opt/pulsar state=directory
     - name: Download Pulsar binary package

--- a/driver-pulsar/pom.xml
+++ b/driver-pulsar/pom.xml
@@ -40,14 +40,14 @@
 
 		<dependency>
 			<groupId>org.apache.pulsar</groupId>
-			<artifactId>pulsar-client</artifactId>
-			<version>1.21.0-incubating</version>
+			<artifactId>pulsar-client-original</artifactId>
+			<version>1.22.0-incubating</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.pulsar</groupId>
-			<artifactId>pulsar-client-admin</artifactId>
-			<version>1.21.0-incubating</version>
+			<artifactId>pulsar-client-admin-original</artifactId>
+			<version>1.22.0-incubating</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -112,13 +112,13 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.2</version>
+			<version>2.9.3</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
-			<version>2.8.3</version>
+			<version>2.9.3</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
- use *original* versions for 1.22.0-incubating, because 1.22.0-incubating has issues on shaded `pulsar-client-admin` due to apache/incubator-pulsar#1370
- explictly specify `jackson-jaxrs-base` and `jackson-jaxrs-json-provider` (see https://stackoverflow.com/questions/38016192/how-to-use-jersey-with-a-newer-version-of-jackson)
- fix the wrong version of jackson