### PR TITLE
Avoid adding negative metric values

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -246,8 +246,10 @@ public class LocalWorker implements Worker, ConsumerCallback {
 
         long now = System.currentTimeMillis();
         long endToEndLatencyMicros = TimeUnit.MILLISECONDS.toMicros(now - publishTimestamp);
-        endToEndCumulativeLatencyRecorder.recordValue(endToEndLatencyMicros);
-        endToEndLatencyRecorder.recordValue(endToEndLatencyMicros);
+        if (endToEndLatencyMicros > 0) {
+            endToEndCumulativeLatencyRecorder.recordValue(endToEndLatencyMicros);
+            endToEndLatencyRecorder.recordValue(endToEndLatencyMicros);
+        }
 
         while (consumersArePaused) {
             try {


### PR DESCRIPTION
`endToEndLatencyMicros` is calculated based on time difference of `System.currentTimeMillis()` on two different machines. It can be negative.