### PR TITLE
Fixed choice of implementation for NoKeyDistributor

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyDistributor.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/distributor/KeyDistributor.java
@@ -53,7 +53,7 @@ public abstract class KeyDistributor {
         KeyDistributor keyDistributor = null;
         switch (keyType) {
             case NO_KEY:
-                keyDistributor = new KeyRoundRobin();
+                keyDistributor = new NoKeyDistributor();
                 break;
             case KEY_ROUND_ROBIN:
                 keyDistributor = new KeyRoundRobin();


### PR DESCRIPTION
When selecting the `NO_KEY` message distributor, we were incorrectlingly still picking `KeyRoundRobin` distributor.