### PR TITLE
Change POM to not use snapshot releases

### DIFF
--- a/driver-bookkeeper/pom.xml
+++ b/driver-bookkeeper/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.apache.distributedlog</groupId>
 			<artifactId>distributedlog-core-shaded</artifactId>
-			<version>4.7.0-SNAPSHOT</version>
+			<version>4.7.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<bookkeeper.version>4.7.0-SNAPSHOT</bookkeeper.version>
+		<bookkeeper.version>4.7.0</bookkeeper.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
As far as I can tell, these versions have been released - consider using
them instead of the SNAPSHOT versions?

(This also makes mvn install work, fixing #64)