### PR TITLE
Support tls and authentication in PulsarDriver

### DIFF
--- a/driver-pulsar/pulsar-effectively-once.yaml
+++ b/driver-pulsar/pulsar-effectively-once.yaml
@@ -33,6 +33,12 @@ client:
     writeQuorum: 3
     ackQuorum: 2
     deduplicationEnabled: true
+  tlsAllowInsecureConnection: false
+  tlsEnableHostnameVerification: false
+  tlsTrustCertsFilePath:
+  authentication:
+    plugin:
+    data:
 
 # Producer configuration
 producer:

--- a/driver-pulsar/pulsar.yaml
+++ b/driver-pulsar/pulsar.yaml
@@ -33,6 +33,12 @@ client:
     writeQuorum: 3
     ackQuorum: 2
     deduplicationEnabled: false
+  tlsAllowInsecureConnection: false
+  tlsEnableHostnameVerification: false
+  tlsTrustCertsFilePath:
+  authentication:
+    plugin:
+    data:
 
 # Producer configuration
 producer:

--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/config/PulsarClientConfig.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/config/PulsarClientConfig.java
@@ -42,4 +42,17 @@ public class PulsarClientConfig {
 
         public boolean deduplicationEnabled = false;
     }
+
+    public boolean tlsAllowInsecureConnection = false;
+
+    public boolean tlsEnableHostnameVerification = false;
+
+    public String tlsTrustCertsFilePath;
+
+    public AuthenticationConfiguration authentication = new AuthenticationConfiguration();
+
+    public static class AuthenticationConfiguration {
+        public String plugin;
+        public String data;
+    }
 }


### PR DESCRIPTION
- Add tls and authentication to PulsarClient and PulsarAdmin in `PulsarDriver`
  - If the beginning of `serviceUrl` matches "pulsar+ssl", use tls in PulsarClient.
  - If the beginning of `httpUrl` matches "https", use tls in PulsarAdmin.
  - If `authentication.plugin` is not empty, use authentication. 