### PR TITLE
Fix pulsar driver log

### DIFF
--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkDriver.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkDriver.java
@@ -122,7 +122,7 @@ public class PulsarBenchmarkDriver implements BenchmarkDriver {
 
             this.namespace = config.client.namespacePrefix + "-" + getRandomString();
             adminClient.namespaces().createNamespace(namespace);
-            log.info("Created Pulsar namespace {}/{}/{}", tenant, cluster, namespace);
+            log.info("Created Pulsar namespace {}", namespace);
 
             PersistenceConfiguration p = config.client.persistence;
             adminClient.namespaces().setPersistence(namespace,


### PR DESCRIPTION
I fixed wrong namespace.
```
09:02:33.852 [main] INFO - Created Pulsar namespace benchmark/dev-cluster/benchmark/dev-cluster/openmessaging-wh08UjI
↓
09:12:57.610 [main] INFO - Created Pulsar namespace benchmark/dev-cluster/openmessaging-tdKRgAc
```