### PR TITLE
[ISSUE#85]Fix request timeout

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
@@ -319,7 +319,7 @@ public class DistributedWorkersEnsemble implements Worker {
 
     private static final ObjectWriter writer = new ObjectMapper().writerWithDefaultPrettyPrinter();
 
-    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
+    private static final ObjectMapper mapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     static {


### PR DESCRIPTION
ObjectMapper parameter JsonFactory should not be YAMLFactory in DistributedWorkersEnsemble.java, it will bring a request timeout when analyzing json content from workers