### PR TITLE
[ISSUE#84] Fix zero publish rate

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -241,6 +241,10 @@ public class LocalWorker implements Worker, ConsumerCallback {
 
     @Override
     public void adjustPublishRate(double publishRate) {
+        if(publishRate < 1.0) {
+            rateLimiter.setRate(1.0);
+            return;
+        }
         rateLimiter.setRate(publishRate);
     }
 


### PR DESCRIPTION
1、AdjustPublishRate can be very small sometimes (for example 0.001msg/s);
2、RateLimiter will make publisher do nothing during the sampling period；
3、Client-host will send a more small publishRate to worker according to sampling result;
4、SO publish rate always zero.
And we set the min publish rate not less than 1.0msg/s can fix it.(sampling period 10s
)