### PR TITLE
Fix tab typo in kafka-exactly-once.yaml

### DIFF
--- a/driver-kafka/kafka-exactly-once.yaml
+++ b/driver-kafka/kafka-exactly-once.yaml
@@ -25,7 +25,7 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 replicationFactor: 3
 
 topicConfig: |
-	min.insync.replicas=2
+  min.insync.replicas=2
 
 commonConfig: |
   bootstrap.servers=localhost:9092


### PR DESCRIPTION
This driver will cause error while running benchmark.