### PR TITLE
Fix current config errors for pulsar config, update pulsar to use 2.1.1

### DIFF
--- a/driver-pulsar/deploy/deploy.yaml
+++ b/driver-pulsar/deploy/deploy.yaml
@@ -54,16 +54,17 @@
           - java
           - sysstat
           - vim
+          - screen
     - set_fact:
         zookeeperServers: "{{ groups['zookeeper']|map('extract', hostvars, ['ansible_default_ipv4', 'address'])|map('regex_replace', '(.*)', '\\1:2181') | join(',') }}"
         serviceUrl: "pulsar://{{ hostvars[groups['pulsar'][0]].private_ip }}:6650/"
         httpUrl: "http://{{ hostvars[groups['pulsar'][0]].private_ip }}:8080/"
-        pulsarVersion: "1.22.0-incubating"
+        pulsarVersion: "2.1.1-incubating"
     - file: path=/opt/pulsar state=absent
     - file: path=/opt/pulsar state=directory
     - name: Download Pulsar binary package
       unarchive:
-        src: "http://archive.apache.org/dist/incubator/pulsar/pulsar-{{ pulsarVersion }}/apache-pulsar-{{ pulsarVersion }}-bin.tar.gz"
+        src: "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-{{ pulsarVersion }}/apache-pulsar-{{ pulsarVersion }}-bin.tar.gz"
         remote_src: yes
         dest: /opt/pulsar
         extra_opts: ["--strip-components=1"]

--- a/driver-pulsar/deploy/templates/bookkeeper.conf
+++ b/driver-pulsar/deploy/templates/bookkeeper.conf
@@ -91,7 +91,7 @@ entryLogFilePreallocationEnabled=true
 
 # Max file size of entry logger, in bytes
 # A new entry log file will be created when the old one reaches the file size limitation
-logSizeLimit=2147483648
+logSizeLimit=1073741824
 
 # Threshold of minor compaction
 # For those entry log files whose remaining size percentage reaches below
@@ -317,7 +317,7 @@ writeBufferSizeBytes=65536
 useHostNameAsBookieID=false
 
 # Stats Provider Class
-statsProviderClass=org.apache.bookkeeper.stats.PrometheusMetricsProvider
+# statsProviderClass=org.apache.bookkeeper.stats.PrometheusMetricsProvider
 # Default port for Prometheus metrics exporter
 prometheusStatsHttpPort=8000
 

--- a/driver-pulsar/pom.xml
+++ b/driver-pulsar/pom.xml
@@ -29,8 +29,8 @@
 	</parent>
 
 	<artifactId>driver-pulsar</artifactId>
-	<properties>	
-		<pulsar.version>2.1.0-incubating</pulsar.version>
+	<properties>
+		<pulsar.version>2.1.1-incubating</pulsar.version>
 	</properties>
 
 	<dependencies>

--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkDriver.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkDriver.java
@@ -88,7 +88,7 @@ public class PulsarBenchmarkDriver implements BenchmarkDriver {
                             .tlsTrustCertsFilePath(config.client.tlsTrustCertsFilePath);
         }
 
-        if (!config.client.authentication.plugin.isEmpty()) {
+        if (config.client.authentication.plugin != null && !config.client.authentication.plugin.isEmpty()) {
             clientBuilder.authentication(config.client.authentication.plugin, config.client.authentication.data);
             pulsarAdminBuilder.authentication(config.client.authentication.plugin, config.client.authentication.data);
         }


### PR DESCRIPTION
The issue that met:
- binary file download too slow
- Bookie config error for logSizeLimit
- npe in PulsarBenchmarkDriver.java