### PR TITLE
Fix benchmark on generating bootstrap & zk servers and adjust pulsar settings

### DIFF
--- a/driver-bookkeeper/deploy/deploy.yaml
+++ b/driver-bookkeeper/deploy/deploy.yaml
@@ -70,8 +70,8 @@
         extra_opts: ["--strip-components=1"]
     - set_fact:
         private_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
-        max_heap_memory: "24g"
-        max_direct_memory: "24g"
+        max_heap_memory: "6g"
+        max_direct_memory: "6g"
     - template:
         src: "templates/pulsar_env.sh"
         dest: "/opt/pulsar/conf/pulsar_env.sh"

--- a/driver-bookkeeper/deploy/terraform.tfvars
+++ b/driver-bookkeeper/deploy/terraform.tfvars
@@ -1,6 +1,6 @@
 public_key_path = "~/.ssh/bookkeeper_aws.pub"
-region          = "us-east-2"
-ami             = "ami-0b1e356e" // RHEL-7.4
+region          = "us-west-2"
+ami             = "ami-9fa343e7" // RHEL-7.4
 
 instance_types = {
   "bookkeeper"  = "i3.4xlarge"

--- a/driver-kafka/deploy/deploy.yaml
+++ b/driver-kafka/deploy/deploy.yaml
@@ -51,9 +51,11 @@
     - file: path=/opt/kafka state=absent
     - file: path=/opt/kafka state=directory
     - set_fact:
-        zookeeperServers: "{{ groups['zookeeper']|map('extract', hostvars, ['ansible_default_ipv4', 'address'])|map('regex_replace', '(.*)', '\\1:2181') | join(',') }}"
-        boostrapServers: "{{ hostvars[groups['kafka'][0]].private_ip }}:9092"
-        kafkaVersion: "1.0.0"
+        zookeeperServers: "{{ groups['zookeeper'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | map('regex_replace', '^(.*)$', '\\1:2181') | join(',') }}"
+        boostrapServers: "{{ groups['kafka'] | map('extract', hostvars, ['private_ip']) | map('regex_replace', '^(.*)$', '\\1:9092') | join(',') }}"
+        kafkaVersion: "2.0.0"
+    - debug:
+        msg: "zookeeper servers: {{ zookeeperServers }}\nboostrap servers: {{ boostrapServers }}"
     - name: Download Kafka package
       unarchive:
         src: http://mirrors.ocf.berkeley.edu/apache/kafka/{{ kafkaVersion }}/kafka_2.11-{{ kafkaVersion }}.tgz

--- a/driver-pulsar/deploy/deploy.yaml
+++ b/driver-pulsar/deploy/deploy.yaml
@@ -56,7 +56,7 @@
           - vim
           - screen
     - set_fact:
-        zookeeperServers: "{{ groups['zookeeper']|map('extract', hostvars, ['ansible_default_ipv4', 'address'])|map('regex_replace', '(.*)', '\\1:2181') | join(',') }}"
+        zookeeperServers: "{{ groups['zookeeper'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | map('regex_replace', '^(.*)$', '\\1:2181') | join(',') }}"
         serviceUrl: "pulsar://{{ hostvars[groups['pulsar'][0]].private_ip }}:6650/"
         httpUrl: "http://{{ hostvars[groups['pulsar'][0]].private_ip }}:8080/"
         pulsarVersion: "2.1.1-incubating"
@@ -70,8 +70,8 @@
         extra_opts: ["--strip-components=1"]
     - set_fact:
         private_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
-        max_heap_memory: "24g"
-        max_direct_memory: "24g"
+        max_heap_memory: "6g"
+        max_direct_memory: "6g"
     - template:
         src: "templates/pulsar_env.sh"
         dest: "/opt/pulsar/conf/pulsar_env.sh"

--- a/driver-pulsar/deploy/templates/bookkeeper.conf
+++ b/driver-pulsar/deploy/templates/bookkeeper.conf
@@ -26,10 +26,11 @@ advertisedAddress={{ hostvars[inventory_hostname].private_ip }}
 journalDirectories=/mnt/journal/1,/mnt/journal/2,/mnt/journal/3,/mnt/journal/4
 ledgerDirectories=/mnt/storage
 
-dbStorage_writeCacheMaxSizeMb=4096
-dbStorage_readAheadCacheMaxSizeMb=4096
-dbStorage_rocksDB_blockCacheSize=4294967296
+dbStorage_writeCacheMaxSizeMb=1024
+dbStorage_readAheadCacheMaxSizeMb=1024
+dbStorage_rocksDB_blockCacheSize=1073741824
 
+journalSyncData=true
 
 ## Regular Bookie settings
 
@@ -151,7 +152,7 @@ journalMaxBackups=5
 journalPreAllocSizeMB=16
 
 # Size of the write buffers used for the journal
-journalWriteBufferSizeKB=64
+journalWriteBufferSizeKB=256
 
 # Should we remove pages from page cache after force write
 journalRemoveFromPageCache=true
@@ -294,7 +295,8 @@ auditorPeriodicBookieCheckInterval=86400
 
 # number of threads that should handle write requests. if zero, the writes would
 # be handled by netty threads directly.
-numAddWorkerThreads=0
+numAddWorkerThreads=8
+maxPendingAddRequestsPerThread=1000000
 
 # number of threads that should handle read requests. if zero, the reads would
 # be handled by netty threads directly.
@@ -302,13 +304,13 @@ numReadWorkerThreads=8
 
 # If read workers threads are enabled, limit the number of pending requests, to
 # avoid the executor queue to grow indefinitely
-maxPendingReadRequestsPerThread=2500
+maxPendingReadRequestsPerThread=1000000
 
 # The number of bytes we should use as capacity for BufferedReadChannel. Default is 512 bytes.
 readBufferSizeBytes=4096
 
 # The number of bytes used as capacity for the write buffer. Default is 64KB.
-writeBufferSizeBytes=65536
+writeBufferSizeBytes=524288
 
 # Whether the bookie should use its hostname to register with the
 # co-ordination service(eg: zookeeper service).


### PR DESCRIPTION


This PR includes changes:

- fix generating bootstrap & zk servers (some ansiable version will generate servers with duplicated ports)
- fix pulsar jvm settings to be aligned with settings of kafka
- tune bookkeeper performance settings