### PR TITLE
Fix an unsupported https url link

### DIFF
--- a/driver-kafka/README.md
+++ b/driver-kafka/README.md
@@ -1,3 +1,3 @@
 # Apache Kafka benchmarks
 
-For instructions on running the OpenMessaging bencmarks for Kafka, see the [official documentation](https://openmessaging.cloud/docs/benchmarks/kafka).
+For instructions on running the OpenMessaging bencmarks for Kafka, see the [official documentation](http://openmessaging.cloud/docs/benchmarks/kafka).


### PR DESCRIPTION
HTTPS protocol is not supported by the OpenMessaing official site currently. so link to the offical site should be started with http://.