### PR TITLE
Modify the way RocketMQ driver create producer for topics

### DIFF
--- a/driver-rocketmq/src/main/java/io/openmessaging/benchmark/driver/rocketmq/RocketMQBenchmarkProducer.java
+++ b/driver-rocketmq/src/main/java/io/openmessaging/benchmark/driver/rocketmq/RocketMQBenchmarkProducer.java
@@ -65,6 +65,6 @@ public class RocketMQBenchmarkProducer implements BenchmarkProducer {
 
     @Override
     public void close() throws Exception {
-        this.rmqProducer.shutdown();
+        /** producer close in driver **/
     }
 }

--- a/driver-rocketmq/src/main/java/io/openmessaging/benchmark/driver/rocketmq/RocketMQBenchmarkProducer.java
+++ b/driver-rocketmq/src/main/java/io/openmessaging/benchmark/driver/rocketmq/RocketMQBenchmarkProducer.java
@@ -65,6 +65,6 @@ public class RocketMQBenchmarkProducer implements BenchmarkProducer {
 
     @Override
     public void close() throws Exception {
-        /** producer close in driver **/
+        // Close in Driver
     }
 }


### PR DESCRIPTION
Topic is bound with producer in RocketMQ-driver while it should be bound with message just as Kafka-driver does.
The way RocketMQ driver create producer for topics should be modified