### PR TITLE
Configure both disks in Kafka deployment

### DIFF
--- a/driver-kafka/deploy/deploy.yaml
+++ b/driver-kafka/deploy/deploy.yaml
@@ -24,17 +24,23 @@
   tasks:
     - command: >
         tuned-adm profile latency-performance
-    - name: Format block device
+    - name: Format disks
       filesystem:
-        fstype: xfs
-        dev: /dev/nvme0n1
-    - name: Create and mount disks
+         fstype: xfs
+         dev: '{{ item }}'
+      with_items:
+        - '/dev/nvme0n1'
+        - '/dev/nvme1n1'
+    - name: Mount disks
       mount:
-        path: /mnt/data
-        src: /dev/nvme0n1
+        path: "{{ item.path }}"
+        src: "{{ item.src }}"
         fstype: xfs
         opts: defaults,noatime,nodiscard
         state: mounted
+      with_items:
+        - { path: "/mnt/data-1", src: "/dev/nvme0n1" }
+        - { path: "/mnt/data-2", src: "/dev/nvme1n1" }
 
 - name: Kafka setup
   hosts: all
@@ -68,7 +74,7 @@
       shell: |
         echo 'LANG=en_US.utf-8
               LC_ALL=en_US.utf-8' > /etc/environment
-        
+
 - name: Setup ZooKeeper
   hosts: zookeeper
   connection: ssh

--- a/driver-kafka/deploy/templates/server.properties
+++ b/driver-kafka/deploy/templates/server.properties
@@ -22,6 +22,6 @@ broker.id={{ brokerId }}
 
 advertised.listeners=PLAINTEXT://{{ privateIp }}:9092
 
-log.dirs=/mnt/data
+log.dirs=/mnt/data-1,/mnt/data-2
 
 zookeeper.connect={{ zookeeperServers }}


### PR DESCRIPTION
Configure both disks in Kafka deployment.

Another options could be to use software RAID-0 to get one logical volume.

cc/ @revans2
