### PR TITLE
add namespace bundles config to pulsar benchmark

### DIFF
--- a/driver-pulsar/pulsar.yaml
+++ b/driver-pulsar/pulsar.yaml
@@ -27,6 +27,7 @@ client:
   ioThreads: 8
   connectionsPerBroker: 8
   namespacePrefix: benchmark/local/ns
+  namespaceBundles: 4
   topicType: persistent
   persistence:
     ensembleSize: 3

--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkDriver.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkDriver.java
@@ -110,6 +110,7 @@ public class PulsarBenchmarkDriver implements BenchmarkDriver {
             // Create namespace and set the configuration
             String tenant = config.client.namespacePrefix.split("/")[0];
             String cluster = config.client.namespacePrefix.split("/")[1];
+            int bundles = config.client.namespaceBundles;
             if (!adminClient.tenants().getTenants().contains(tenant)) {
                 try {
                     adminClient.tenants().createTenant(tenant,
@@ -121,8 +122,8 @@ public class PulsarBenchmarkDriver implements BenchmarkDriver {
             log.info("Created Pulsar tenant {} with allowed cluster {}", tenant, cluster);
 
             this.namespace = config.client.namespacePrefix + "-" + getRandomString();
-            adminClient.namespaces().createNamespace(namespace);
-            log.info("Created Pulsar namespace {}", namespace);
+            adminClient.namespaces().createNamespace(namespace, bundles);
+            log.info("Created Pulsar namespace {} with {} bundles", namespace, bundles);
 
             PersistenceConfiguration p = config.client.persistence;
             adminClient.namespaces().setPersistence(namespace,

--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/config/PulsarClientConfig.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/config/PulsarClientConfig.java
@@ -32,6 +32,8 @@ public class PulsarClientConfig {
     public String namespacePrefix;
 
     public TopicDomain topicType = TopicDomain.persistent;
+    
+    public int namespaceBundles = 4;
 
     public PersistenceConfiguration persistence = new PersistenceConfiguration();
 


### PR DESCRIPTION
### Motivation
Sometimes, it needs to spread load across multiple brokers using one namespace in benchmark test and in pulsar, it can be done by defining multiple bundles for a namespace. So, provide a configuration to define namespace bundle for a namespace.