### PR TITLE
Update to latest Pulsar version

### DIFF
--- a/driver-pulsar/deploy/deploy.yaml
+++ b/driver-pulsar/deploy/deploy.yaml
@@ -59,7 +59,7 @@
         zookeeperServers: "{{ groups['zookeeper'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | map('regex_replace', '^(.*)$', '\\1:2181') | join(',') }}"
         serviceUrl: "pulsar://{{ hostvars[groups['pulsar'][0]].private_ip }}:6650/"
         httpUrl: "http://{{ hostvars[groups['pulsar'][0]].private_ip }}:8080/"
-        pulsarVersion: "2.1.1-incubating"
+        pulsarVersion: "2.3.1"
     - file: path=/opt/pulsar state=absent
     - file: path=/opt/pulsar state=directory
     - name: Download Pulsar binary package


### PR DESCRIPTION
The old version (2.1.1-incubating) was failing to download during the ansible run. I updated to the latest version (2.3.1) and it worked fine.