### PR TITLE
Update Pulsar drivers to work with 2.4.0 plus fix aggregate latency

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -442,14 +442,14 @@ public class WorkloadGenerator implements AutoCloseable {
                 result.aggregatedPublishLatency9999pct = agg.publishLatency.getValueAtPercentile(99.99) / 1000.0;
                 result.aggregatedPublishLatencyMax = agg.publishLatency.getMaxValue() / 1000.0;
 
-                result.aggregatedEndToEndLatencyAvg = agg.endToEndLatency.getMean();
-                result.aggregatedEndToEndLatency50pct = agg.endToEndLatency.getValueAtPercentile(50);
-                result.aggregatedEndToEndLatency75pct = agg.endToEndLatency.getValueAtPercentile(75);
-                result.aggregatedEndToEndLatency95pct = agg.endToEndLatency.getValueAtPercentile(95);
-                result.aggregatedEndToEndLatency99pct = agg.endToEndLatency.getValueAtPercentile(99);
-                result.aggregatedEndToEndLatency999pct = agg.endToEndLatency.getValueAtPercentile(99.9);
-                result.aggregatedEndToEndLatency9999pct = agg.endToEndLatency.getValueAtPercentile(99.99);
-                result.aggregatedEndToEndLatencyMax = agg.endToEndLatency.getMaxValue();
+                result.aggregatedEndToEndLatencyAvg = agg.endToEndLatency.getMean()  / 1000.0;
+                result.aggregatedEndToEndLatency50pct = agg.endToEndLatency.getValueAtPercentile(50)  / 1000.0;
+                result.aggregatedEndToEndLatency75pct = agg.endToEndLatency.getValueAtPercentile(75)  / 1000.0;
+                result.aggregatedEndToEndLatency95pct = agg.endToEndLatency.getValueAtPercentile(95)  / 1000.0;
+                result.aggregatedEndToEndLatency99pct = agg.endToEndLatency.getValueAtPercentile(99)  / 1000.0;
+                result.aggregatedEndToEndLatency999pct = agg.endToEndLatency.getValueAtPercentile(99.9)  / 1000.0;
+                result.aggregatedEndToEndLatency9999pct = agg.endToEndLatency.getValueAtPercentile(99.99)  / 1000.0;
+                result.aggregatedEndToEndLatencyMax = agg.endToEndLatency.getMaxValue()  / 1000.0;
 
                 agg.publishLatency.percentiles(100).forEach(value -> {
                     result.aggregatedPublishLatencyQuantiles.put(value.getPercentile(),

--- a/driver-pulsar/deploy/deploy.yaml
+++ b/driver-pulsar/deploy/deploy.yaml
@@ -59,7 +59,7 @@
         zookeeperServers: "{{ groups['zookeeper'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | map('regex_replace', '^(.*)$', '\\1:2181') | join(',') }}"
         serviceUrl: "pulsar://{{ hostvars[groups['pulsar'][0]].private_ip }}:6650/"
         httpUrl: "http://{{ hostvars[groups['pulsar'][0]].private_ip }}:8080/"
-        pulsarVersion: "2.3.1"
+        pulsarVersion: "2.4.0"
     - file: path=/opt/pulsar state=absent
     - file: path=/opt/pulsar state=directory
     - name: Download Pulsar binary package
@@ -113,7 +113,7 @@
     - command: >
         bin/pulsar initialize-cluster-metadata --cluster local
         --zookeeper localhost:2181
-        --global-zookeeper localhost:2181
+        --configuration-store localhost:2181
         --web-service-url {{ httpUrl }}
         --broker-service-url {{ serviceUrl }}
       args:

--- a/driver-pulsar/deploy/deploy.yaml
+++ b/driver-pulsar/deploy/deploy.yaml
@@ -55,6 +55,7 @@
           - sysstat
           - vim
           - screen
+          - chrony
     - set_fact:
         zookeeperServers: "{{ groups['zookeeper'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | map('regex_replace', '^(.*)$', '\\1:2181') | join(',') }}"
         serviceUrl: "pulsar://{{ hostvars[groups['pulsar'][0]].private_ip }}:6650/"
@@ -153,6 +154,20 @@
         state: restarted
         daemon_reload: yes
         name: "pulsar"
+
+- name: Chrony setup 
+  hosts: client
+  connection: ssh
+  become: true
+  tasks:
+    - name: Set up chronyd
+      template:
+        src: "templates/chrony.conf"
+        dest: "/etc/chrony.conf"
+    - systemd:
+        state: restarted
+        daemon_reload: yes
+        name: "chronyd"
 
 - name: Get Maven version
   hosts: localhost

--- a/driver-pulsar/deploy/deploy_with_stats.yaml
+++ b/driver-pulsar/deploy/deploy_with_stats.yaml
@@ -55,15 +55,15 @@
           - sysstat
           - vim
     - set_fact:
-        zookeeperServers: "{{ groups['zookeeper']|map('extract', hostvars, ['ansible_default_ipv4', 'address'])|map('regex_replace', '(.*)', '\\1:2181') | join(',') }}"
+        zookeeperServers: "{{ groups['zookeeper'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | map('regex_replace', '^(.*)$', '\\1:2181') | join(',') }}"
         serviceUrl: "pulsar://{{ hostvars[groups['pulsar'][0]].private_ip }}:6650/"
         httpUrl: "http://{{ hostvars[groups['pulsar'][0]].private_ip }}:8080/"
-        pulsarVersion: "1.22.0-incubating"
+        pulsarVersion: "2.4.0"
     - file: path=/opt/pulsar state=absent
     - file: path=/opt/pulsar state=directory
     - name: Download Pulsar binary package
       unarchive:
-        src: "http://archive.apache.org/dist/incubator/pulsar/pulsar-{{ pulsarVersion }}/apache-pulsar-{{ pulsarVersion }}-bin.tar.gz"
+        src: "http://archive.apache.org/dist/pulsar/pulsar-{{ pulsarVersion }}/apache-pulsar-{{ pulsarVersion }}-bin.tar.gz"
         remote_src: yes
         dest: /opt/pulsar
         extra_opts: ["--strip-components=1"]
@@ -112,7 +112,7 @@
     - command: >
         bin/pulsar initialize-cluster-metadata --cluster local
         --zookeeper localhost:2181
-        --global-zookeeper localhost:2181
+        --configuration-store localhost:2181
         --web-service-url {{ httpUrl }}
         --broker-service-url {{ serviceUrl }}
       args:

--- a/driver-pulsar/deploy/deploy_with_stats.yaml
+++ b/driver-pulsar/deploy/deploy_with_stats.yaml
@@ -54,6 +54,7 @@
           - java
           - sysstat
           - vim
+          - chrony
     - set_fact:
         zookeeperServers: "{{ groups['zookeeper'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | map('regex_replace', '^(.*)$', '\\1:2181') | join(',') }}"
         serviceUrl: "pulsar://{{ hostvars[groups['pulsar'][0]].private_ip }}:6650/"
@@ -152,6 +153,21 @@
         state: restarted
         daemon_reload: yes
         name: "pulsar"
+
+- name: Chrony setup
+  hosts: client
+  connection: ssh
+  become: true
+  tasks:
+    - name: Set up chronyd
+      template:
+        src: "templates/chrony.conf"
+        dest: "/etc/chrony.conf"
+    - systemd:
+        state: restarted
+        daemon_reload: yes
+        name: "chronyd"
+
 
 - name: Get Maven version
   hosts: localhost

--- a/driver-pulsar/deploy/templates/chrony.conf
+++ b/driver-pulsar/deploy/templates/chrony.conf
@@ -1,0 +1,35 @@
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+server 169.254.169.123 prefer iburst
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access from local network.
+#allow 192.168.0.0/16
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/driver-pulsar/pulsar-effectively-once.yaml
+++ b/driver-pulsar/pulsar-effectively-once.yaml
@@ -26,7 +26,8 @@ client:
   httpUrl: http://localhost:8080
   ioThreads: 8
   connectionsPerBroker: 8
-  namespacePrefix: benchmark/local/ns
+  clusterName: local
+  namespacePrefix: benchmark/ns
   topicType: persistent
   persistence:
     ensembleSize: 3

--- a/driver-pulsar/pulsar.yaml
+++ b/driver-pulsar/pulsar.yaml
@@ -26,7 +26,8 @@ client:
   httpUrl: http://localhost:8080
   ioThreads: 8
   connectionsPerBroker: 8
-  namespacePrefix: benchmark/local/ns
+  clusterName: local
+  namespacePrefix: benchmark/ns
   topicType: persistent
   persistence:
     ensembleSize: 3

--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkDriver.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkDriver.java
@@ -64,6 +64,7 @@ public class PulsarBenchmarkDriver implements BenchmarkDriver {
     private PulsarConfig config;
 
 
+
     private String namespace;
     private ProducerBuilder<byte[]> producerBuilder;
 
@@ -109,7 +110,7 @@ public class PulsarBenchmarkDriver implements BenchmarkDriver {
         try {
             // Create namespace and set the configuration
             String tenant = config.client.namespacePrefix.split("/")[0];
-            String cluster = config.client.namespacePrefix.split("/")[1];
+            String cluster = config.client.clusterName;
             if (!adminClient.tenants().getTenants().contains(tenant)) {
                 try {
                     adminClient.tenants().createTenant(tenant,

--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/config/PulsarClientConfig.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/config/PulsarClientConfig.java
@@ -31,6 +31,8 @@ public class PulsarClientConfig {
 
     public String namespacePrefix;
 
+    public String clusterName;
+
     public TopicDomain topicType = TopicDomain.persistent;
 
     public PersistenceConfiguration persistence = new PersistenceConfiguration();


### PR DESCRIPTION
In order to get the Pulsar driver to work with 2.4.0, I made the following changes:

- Remove the assumption that the cluster name is part of the namespace/topic name. Prior to PIP-10, the cluster name was part of the namespace/topic name. This was confusing for new users who are used to the new naming convention and it doesn't play nice with the REST admin interface.

- Changed the global-zookeeper option to configuration-store to match the new name

I also fixed the benchmark calculations for aggregate end-to-end latency. Unlike all the other latency calculations, those were being reported in microseconds, not milliseconds.