### PR TITLE
Updated pulsar client to 2.4.1

### DIFF
--- a/driver-pulsar/pom.xml
+++ b/driver-pulsar/pom.xml
@@ -30,7 +30,7 @@
 
 	<artifactId>driver-pulsar</artifactId>
 	<properties>
-		<pulsar.version>2.1.1-incubating</pulsar.version>
+		<pulsar.version>2.4.1</pulsar.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
While the pulsar broker in the Ansible deployment was updated, the client was still using a very old library.