### PR TITLE
Use exec when starting JVM

### DIFF
--- a/bin/benchmark-worker
+++ b/bin/benchmark-worker
@@ -27,4 +27,4 @@ fi
 JVM_MEM="-Xms4G -Xmx4G -XX:+UseG1GC"
 JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
-java -server -cp $CLASSPATH $JVM_MEM io.openmessaging.benchmark.worker.BenchmarkWorker $*
+exec java -server -cp $CLASSPATH $JVM_MEM io.openmessaging.benchmark.worker.BenchmarkWorker $*


### PR DESCRIPTION
Using exec when running the benchmark inside the container will make sure the `SIGQUIT` to pid 1 is correctly passed to the JVM instead of the bash process.