### PR TITLE
add memory request/limits to the benchmark driver

### DIFF
--- a/deployment/kubernetes/helm/benchmark/templates/benchmark.yaml
+++ b/deployment/kubernetes/helm/benchmark/templates/benchmark.yaml
@@ -29,6 +29,11 @@ spec:
     - name: {{ .Release.Name }}-driver
       imagePullPolicy: {{ .Values.imagePullPolicy }}
       image: {{ .Values.image }}
+      resources:
+        limits:
+          memory: {{ .Values.driverMemoryLimit }}
+        requests:
+          memory: {{ .Values.driverMemoryRequest }}
       env:
         - name: NUM_WORKERS
           value: "{{ .Values.numWorkers }}"

--- a/deployment/kubernetes/helm/benchmark/values.yaml
+++ b/deployment/kubernetes/helm/benchmark/values.yaml
@@ -22,3 +22,5 @@ image: openmessaging/openmessaging-benchmark:latest
 imagePullPolicy: Always
 workload: workloads/1-topic-16-partitions-1kb.yaml
 driver: driver-pulsar/pulsar.yaml
+driverMemoryRequest: 512Mi
+driverMemoryLimit: 2048Mi


### PR DESCRIPTION
This PR just add basic memory and limits requests, to avoid hitting issues because of no limits in the driver.
As the driver is more memory intensive I'm only opening the PR with memory limits