### PR TITLE
Update Pulsar to 2.8.0 and fix Benchmark worker

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -174,7 +174,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>9.4.35.v20201120</version>
+			<version>9.4.42.v20210604</version>
 		</dependency>
 
 		<dependency>
@@ -187,8 +187,9 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-util</artifactId>
-			<version>9.4.8.v20171121</version>
+			<version>9.4.42.v20210604</version>
 		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/driver-pulsar/pom.xml
+++ b/driver-pulsar/pom.xml
@@ -30,7 +30,7 @@
 
 	<artifactId>driver-pulsar</artifactId>
 	<properties>
-		<pulsar.version>2.4.1</pulsar.version>
+		<pulsar.version>2.8.0</pulsar.version>
 	</properties>
 
 	<dependencies>

--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkDriver.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkDriver.java
@@ -120,7 +120,7 @@ public class PulsarBenchmarkDriver implements BenchmarkDriver {
             if (!adminClient.tenants().getTenants().contains(tenant)) {
                 try {
                     adminClient.tenants().createTenant(tenant,
-                                    new TenantInfo(Collections.emptySet(), Sets.newHashSet(cluster)));
+                                    TenantInfo.builder().adminRoles(Collections.emptySet()).allowedClusters(Sets.newHashSet(cluster)).build());
                 } catch (ConflictException e) {
                     // Ignore. This can happen when multiple workers are initializing at the same time
                 }
@@ -136,7 +136,7 @@ public class PulsarBenchmarkDriver implements BenchmarkDriver {
                             new PersistencePolicies(p.ensembleSize, p.writeQuorum, p.ackQuorum, 1.0));
 
             adminClient.namespaces().setBacklogQuota(namespace,
-                            new BacklogQuota(Long.MAX_VALUE, RetentionPolicy.producer_exception));
+                    BacklogQuota.builder().limitSize(Long.MAX_VALUE).retentionPolicy(RetentionPolicy.producer_exception).build());
             adminClient.namespaces().setDeduplicationStatus(namespace, p.deduplicationEnabled);
             log.info("Applied persistence configuration for namespace {}/{}/{}: {}", tenant, cluster, namespace,
                             writer.writeValueAsString(p));

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<bookkeeper.version>4.7.0</bookkeeper.version>
+		<bookkeeper.version>4.14.0</bookkeeper.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
Update some third party libraries:
- Pulsar to 2.8.0
- BookKeeper to 4.14.0
- Jetty to 9.4.42.v20210604

With this fix I am also fixing the BenchmarkWorker that does not work anymore, failing with this error:
```
Jul 26 07:18:49 localhost benchmark-worker: 07:18:49.928 [main] INFO - Logging initialized @1934ms to org.eclipse.jetty.util.log.Slf4jLog
Jul 26 07:18:49 localhost benchmark-worker: Exception in thread "main" java.lang.NoClassDefFoundError: org/eclipse/jetty/util/component/AttributeContainerMap
Jul 26 07:18:49 localhost benchmark-worker: at org.eclipse.jetty.server.Server.<init>(Server.java:79)
Jul 26 07:18:49 localhost benchmark-worker: at org.eclipse.jetty.server.Server.<init>(Server.java:122)
Jul 26 07:18:49 localhost benchmark-worker: at org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider.start(PrometheusMetricsProvider.java:103)
Jul 26 07:18:49 localhost benchmark-worker: at io.openmessaging.benchmark.worker.BenchmarkWorker.main(BenchmarkWorker.java:77)
Jul 26 07:18:49 localhost benchmark-worker: Caused by: java.lang.ClassNotFoundException: org.eclipse.jetty.util.component.AttributeContainerMap
Jul 26 07:18:49 localhost benchmark-worker: at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
Jul 26 07:18:49 localhost benchmark-worker: at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
Jul 26 07:18:49 localhost benchmark-worker: at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
Jul 26 07:18:49 localhost benchmark-worker: at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
Jul 26 07:18:49 localhost benchmark-worker: ... 4 more
```
