### PR TITLE
Initial Redis Streams support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository houses user-friendly, cloud-ready benchmarking suites for the fo
 * [RabbitMQ](https://www.rabbitmq.com/)
 * [Apache Pulsar](https://pulsar.apache.org)
 * [NATS Streaming](https://nats.io/)
+* [Redis](https://redis.com/)
 
 > More details could be found at the [official documentation](http://openmessaging.cloud/docs/benchmarks/).
 

--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -147,6 +147,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>driver-redis</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.bookkeeper.stats</groupId>
 			<artifactId>bookkeeper-stats-api</artifactId>
 			<version>${bookkeeper.version}</version>

--- a/driver-redis/pom.xml
+++ b/driver-redis/pom.xml
@@ -1,0 +1,54 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>messaging-benchmark</artifactId>
+        <groupId>io.openmessaging.benchmark</groupId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>driver-redis</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>driver-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>3.6.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+
+    </dependencies>
+
+</project>

--- a/driver-redis/redis.yaml
+++ b/driver-redis/redis.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Redis
+driverClass: io.openmessaging.benchmark.driver.redis.RedisBenchmarkDriver
+
+# Redis client-specific configuration
+redisPort: 6379
+redisHost: 127.0.0.1
+jedisPoolMaxTotal: 8
+jedisPoolMaxIdle: 8

--- a/driver-redis/src/main/java/io/openmessaging/benchmark/driver/redis/RedisBenchmarkConsumer.java
+++ b/driver-redis/src/main/java/io/openmessaging/benchmark/driver/redis/RedisBenchmarkConsumer.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.driver.redis;
+
+import io.openmessaging.benchmark.driver.BenchmarkConsumer;
+import io.openmessaging.benchmark.driver.ConsumerCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.StreamEntry;
+import redis.clients.jedis.StreamEntryID;
+import redis.clients.jedis.params.XReadGroupParams;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class RedisBenchmarkConsumer implements BenchmarkConsumer {
+    private final JedisPool pool;
+    private final String topic;
+    private final String subscriptionName;
+    private final String consumerId;
+    private final ExecutorService executor;
+    private final Future<?> consumerTask;
+    private volatile boolean closing = false;
+
+    public RedisBenchmarkConsumer(final String consumerId, final String topic, final String subscriptionName, final JedisPool pool, ConsumerCallback consumerCallback) {
+        this.pool = pool;
+        this.topic = topic;
+        this.subscriptionName = subscriptionName;
+        this.consumerId = consumerId;
+        this.executor = Executors.newSingleThreadExecutor();
+        Jedis jedis = this.pool.getResource();
+
+
+        this.consumerTask = this.executor.submit(() -> {
+            while (!closing) {
+                try {
+                    Map<String, StreamEntryID> streamQuery = Collections.singletonMap(this.topic, StreamEntryID.UNRECEIVED_ENTRY);
+                    List<Map.Entry<String, List<StreamEntry>>> range = jedis.xreadGroup(this.subscriptionName, this.consumerId,
+                            XReadGroupParams.xReadGroupParams().block(0), streamQuery);
+                    if (range!=null){
+                        for (Map.Entry<String, List<StreamEntry>> streamEntries:
+                                range) {
+                            for (StreamEntry entry:
+                                    streamEntries.getValue()) {
+                                long timestamp = entry.getID().getTime();
+                                byte[]payload = entry.getFields().get("payload").getBytes(StandardCharsets.UTF_8);
+                                consumerCallback.messageReceived(payload, timestamp);
+                            }
+                        }
+                    }
+
+                } catch (Exception e) {
+                    log.error("Failed to read from consumer instance.", e);
+                }
+            }
+        });
+
+    }
+
+    @Override
+    public void close() throws Exception {
+        closing = true;
+        executor.shutdown();
+        consumerTask.get();
+        pool.close();
+    }
+    private static final Logger log = LoggerFactory.getLogger(RedisBenchmarkDriver.class);
+
+}

--- a/driver-redis/src/main/java/io/openmessaging/benchmark/driver/redis/RedisBenchmarkDriver.java
+++ b/driver-redis/src/main/java/io/openmessaging/benchmark/driver/redis/RedisBenchmarkDriver.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.driver.redis;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.io.BaseEncoding;
+import io.openmessaging.benchmark.driver.BenchmarkConsumer;
+import io.openmessaging.benchmark.driver.BenchmarkDriver;
+import io.openmessaging.benchmark.driver.BenchmarkProducer;
+import io.openmessaging.benchmark.driver.ConsumerCallback;
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.*;
+import io.openmessaging.benchmark.driver.redis.client.RedisClientConfig;
+
+
+public class RedisBenchmarkDriver implements BenchmarkDriver {
+    JedisPool jedisPool;
+    private RedisClientConfig clientConfig;
+
+    @Override
+    public void initialize(final File configurationFile, final StatsLogger statsLogger) throws IOException {
+        this.clientConfig = readConfig(configurationFile);
+
+    }
+
+    @Override
+    public String getTopicNamePrefix() {
+        return "redis-openmessaging-benchmark";
+    }
+
+    @Override
+    public CompletableFuture<Void> createTopic(final String topic, final int partitions) {
+        return CompletableFuture.runAsync(() -> {
+        });
+    }
+
+    @Override
+    public CompletableFuture<BenchmarkProducer> createProducer(final String topic) {
+        if (jedisPool == null) {
+            setupJedisConn();
+        }
+        return CompletableFuture.completedFuture(new RedisBenchmarkProducer(jedisPool, topic));
+    }
+
+    @Override
+    public CompletableFuture<BenchmarkConsumer> createConsumer(final String topic, final String subscriptionName,
+        final ConsumerCallback consumerCallback) {
+        String consumerId = "consumer-"+getRandomString();
+        if (jedisPool == null) {
+            setupJedisConn();
+        }
+        try (Jedis jedis = this.jedisPool.getResource()) {
+            jedis.xgroupCreate(topic, subscriptionName, null, true);
+        } catch (Exception e) {
+            log.info("Failed to create consumer instance.", e);
+        }
+        return CompletableFuture.completedFuture(new RedisBenchmarkConsumer( consumerId, topic, subscriptionName,jedisPool, consumerCallback));
+    }
+
+    private void setupJedisConn() {
+        JedisPoolConfig poolConfig = new JedisPoolConfig();
+        poolConfig.setMaxTotal(this.clientConfig.jedisPoolMaxTotal);
+        poolConfig.setMaxIdle(this.clientConfig.jedisPoolMaxIdle);
+        if( this.clientConfig.redisPass != null ){
+            if ( this.clientConfig.redisUser != null){
+                jedisPool = new JedisPool(poolConfig, this.clientConfig.redisHost, this.clientConfig.redisPort, 2000, this.clientConfig.redisPass, this.clientConfig.redisUser);
+            } else {
+            jedisPool = new JedisPool(poolConfig, this.clientConfig.redisHost, this.clientConfig.redisPort,2000, this.clientConfig.redisPass );
+        }
+        } else {
+            jedisPool = new JedisPool(poolConfig, this.clientConfig.redisHost, this.clientConfig.redisPort,2000 );
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (this.jedisPool != null) {
+            this.jedisPool.close();
+        }
+    }
+
+    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private static RedisClientConfig readConfig(File configurationFile) throws IOException {
+        return mapper.readValue(configurationFile, RedisClientConfig.class);
+    }
+
+    private static final Random random = new Random();
+
+    private static final String getRandomString() {
+        byte[] buffer = new byte[5];
+        random.nextBytes(buffer);
+        return BaseEncoding.base64Url().omitPadding().encode(buffer);
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(RedisBenchmarkDriver.class);
+}

--- a/driver-redis/src/main/java/io/openmessaging/benchmark/driver/redis/RedisBenchmarkProducer.java
+++ b/driver-redis/src/main/java/io/openmessaging/benchmark/driver/redis/RedisBenchmarkProducer.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.driver.redis;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import io.openmessaging.benchmark.driver.BenchmarkProducer;
+import redis.clients.jedis.*;
+import redis.clients.jedis.params.XAddParams;
+
+public class RedisBenchmarkProducer implements BenchmarkProducer {
+    private final JedisPool pool;
+    private final String rmqTopic;
+    private final XAddParams xaddParams;
+
+    public RedisBenchmarkProducer(final JedisPool pool, final String rmqTopic) {
+        this.pool = pool;
+        this.rmqTopic = rmqTopic;
+        this.xaddParams = redis.clients.jedis.params.XAddParams.xAddParams();
+    }
+
+    @Override
+    public CompletableFuture<Void> sendAsync(final Optional<String> key, final byte[] payload) {
+        Map<byte[], byte[]> map1 = new HashMap<>();
+        map1.put("payload".getBytes(), payload);
+
+        if (key.isPresent()) {
+            map1.put("key".getBytes(), key.toString().getBytes());
+        }
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+            try (Jedis jedis = this.pool.getResource()) {
+                jedis.xadd(this.rmqTopic.getBytes(),map1, this.xaddParams);
+                future.complete(null);
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        return future;
+    }
+
+    @Override
+    public void close() throws Exception {
+        // Close in Driver
+    }
+}

--- a/driver-redis/src/main/java/io/openmessaging/benchmark/driver/redis/client/RedisClientConfig.java
+++ b/driver-redis/src/main/java/io/openmessaging/benchmark/driver/redis/client/RedisClientConfig.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.driver.redis.client;
+
+public class RedisClientConfig {
+    public String redisHost;
+    public String redisUser;
+    public String redisPass;
+    public Integer redisPort;
+    public Integer jedisPoolMaxTotal;
+    public Integer jedisPoolMaxIdle;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 		<module>driver-nats-streaming</module>
 		<module>driver-nsq</module>
 		<module>driver-jms</module>
+		<module>driver-redis</module>
 		<module>package</module>
 		<module>docker</module>
 	</modules>


### PR DESCRIPTION
This PR kick-off the Redis support via redis [streams](https://redis.io/topics/streams-intro). 
Here's a quick one-liner:

```bash
$ git clone https://github.com/openmessaging/openmessaging-benchmark
$ cd openmessaging-benchmark
$ mvn install
$ bin/benchmark --drivers driver-redis/redis.yaml workloads/1-topic-1-partition-1kb.yaml
```